### PR TITLE
add new polymaker PETG filament data

### DIFF
--- a/data/polymaker/PETG/material.json
+++ b/data/polymaker/PETG/material.json
@@ -1,0 +1,3 @@
+{
+  "material": "PETG"
+}

--- a/data/polymaker/PETG/petg/black/sizes.json
+++ b/data/polymaker/PETG/petg/black/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/black/variant.json
+++ b/data/polymaker/PETG/petg/black/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "black",
+    "name": "Black",
+    "color_hex": "#070908"
+}

--- a/data/polymaker/PETG/petg/blue/sizes.json
+++ b/data/polymaker/PETG/petg/blue/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/blue/variant.json
+++ b/data/polymaker/PETG/petg/blue/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "blue",
+    "name": "Blue",
+    "color_hex": "#1B3B99"
+}

--- a/data/polymaker/PETG/petg/dark_blue/sizes.json
+++ b/data/polymaker/PETG/petg/dark_blue/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/dark_blue/variant.json
+++ b/data/polymaker/PETG/petg/dark_blue/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "dark_blue",
+    "name": "Dark Blue",
+    "color_hex": "#081B36"
+}

--- a/data/polymaker/PETG/petg/dark_green/sizes.json
+++ b/data/polymaker/PETG/petg/dark_green/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/dark_green/variant.json
+++ b/data/polymaker/PETG/petg/dark_green/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "dark_green",
+    "name": "Dark Green",
+    "color_hex": "#223622"
+}

--- a/data/polymaker/PETG/petg/dark_grey/sizes.json
+++ b/data/polymaker/PETG/petg/dark_grey/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/dark_grey/variant.json
+++ b/data/polymaker/PETG/petg/dark_grey/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "dark_grey",
+    "name": "Dark Grey",
+    "color_hex": "#363D40"
+}

--- a/data/polymaker/PETG/petg/dark_purple/sizes.json
+++ b/data/polymaker/PETG/petg/dark_purple/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/dark_purple/variant.json
+++ b/data/polymaker/PETG/petg/dark_purple/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "dark_purple",
+    "name": "Dark Purple",
+    "color_hex": "#352A3B"
+}

--- a/data/polymaker/PETG/petg/electric_blue/sizes.json
+++ b/data/polymaker/PETG/petg/electric_blue/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/electric_blue/variant.json
+++ b/data/polymaker/PETG/petg/electric_blue/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "electric_blue",
+    "name": "Electric Blue",
+    "color_hex": "#3E8CE4"
+}

--- a/data/polymaker/PETG/petg/filament.json
+++ b/data/polymaker/PETG/petg/filament.json
@@ -1,0 +1,6 @@
+{
+    "id": "petg",
+    "name": "PETG",
+    "diameter_tolerance": 0.02,
+    "density": 1.25
+}

--- a/data/polymaker/PETG/petg/green/sizes.json
+++ b/data/polymaker/PETG/petg/green/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/green/variant.json
+++ b/data/polymaker/PETG/petg/green/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "green",
+    "name": "Green",
+    "color_hex": "#38B837"
+}

--- a/data/polymaker/PETG/petg/grey/sizes.json
+++ b/data/polymaker/PETG/petg/grey/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/grey/variant.json
+++ b/data/polymaker/PETG/petg/grey/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "grey",
+    "name": "Grey",
+    "color_hex": "#A7AEB2"
+}

--- a/data/polymaker/PETG/petg/lime/sizes.json
+++ b/data/polymaker/PETG/petg/lime/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/lime/variant.json
+++ b/data/polymaker/PETG/petg/lime/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "lime",
+    "name": "Lime",
+    "color_hex": "#F8FF6B"
+}

--- a/data/polymaker/PETG/petg/magenta/sizes.json
+++ b/data/polymaker/PETG/petg/magenta/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/magenta/variant.json
+++ b/data/polymaker/PETG/petg/magenta/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "magenta",
+    "name": "Magenta",
+    "color_hex": "#DC5D8C"
+}

--- a/data/polymaker/PETG/petg/orange/sizes.json
+++ b/data/polymaker/PETG/petg/orange/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/orange/variant.json
+++ b/data/polymaker/PETG/petg/orange/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "orange",
+    "name": "Orange",
+    "color_hex": "#DC7C40"
+}

--- a/data/polymaker/PETG/petg/pink/sizes.json
+++ b/data/polymaker/PETG/petg/pink/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/pink/variant.json
+++ b/data/polymaker/PETG/petg/pink/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "pink",
+    "name": "Pink",
+    "color_hex": "#F5BEE9"
+}

--- a/data/polymaker/PETG/petg/purple/sizes.json
+++ b/data/polymaker/PETG/petg/purple/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/purple/variant.json
+++ b/data/polymaker/PETG/petg/purple/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "purple",
+    "name": "Purple",
+    "color_hex": "#6947B8"
+}

--- a/data/polymaker/PETG/petg/red/sizes.json
+++ b/data/polymaker/PETG/petg/red/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/red/variant.json
+++ b/data/polymaker/PETG/petg/red/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "red",
+    "name": "Red",
+    "color_hex": "#C23320"
+}

--- a/data/polymaker/PETG/petg/silver/sizes.json
+++ b/data/polymaker/PETG/petg/silver/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/silver/variant.json
+++ b/data/polymaker/PETG/petg/silver/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "silver",
+    "name": "Silver",
+    "color_hex": "#707478"
+}

--- a/data/polymaker/PETG/petg/teal/sizes.json
+++ b/data/polymaker/PETG/petg/teal/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/teal/variant.json
+++ b/data/polymaker/PETG/petg/teal/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "teal",
+    "name": "Teal",
+    "color_hex": "#74CABF"
+}

--- a/data/polymaker/PETG/petg/white/sizes.json
+++ b/data/polymaker/PETG/petg/white/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/white/variant.json
+++ b/data/polymaker/PETG/petg/white/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "white",
+    "name": "White",
+    "color_hex": "#F8FAF8"
+}

--- a/data/polymaker/PETG/petg/yellow/sizes.json
+++ b/data/polymaker/PETG/petg/yellow/sizes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 3000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  },
+  {
+    "filament_weight": 5000,
+    "diameter": 2.85,
+    "purchase_links": [
+      {
+        "store_id": "polymaker",
+        "url": "https://us.polymaker.com/products/polymaker-petg?"
+      }
+    ]
+  }
+]

--- a/data/polymaker/PETG/petg/yellow/variant.json
+++ b/data/polymaker/PETG/petg/yellow/variant.json
@@ -1,0 +1,5 @@
+{
+    "id": "yellow",
+    "name": "Yellow",
+    "color_hex": "#FBE95C"
+}


### PR DESCRIPTION
Polymaker is phasing out PETG lite in favor of their new Polymaker PETG formula. There isn't full color overlap, and the colors in the new formula are all slightly different.

I'm not certain about the tolerance value, as I could not find this in the data they provide about this new PETG offering. Since this is allegedly an improvement over Polylite I assumed the same quality for now.