### PR TITLE
fix: correct eryone website from fiberlogy.com to eryone3d.com

### DIFF
--- a/data/eryone/brand.json
+++ b/data/eryone/brand.json
@@ -1,7 +1,7 @@
 {
   "id": "eryone",
   "name": "Eryone",
-  "website": "https://fiberlogy.com/",
+  "website": "https://eryone3d.com/",
   "logo": "logo.png",
   "origin": "CN",
   "source": "openprinttag"


### PR DESCRIPTION
## Summary

Corrects the Eryone brand website URL from `fiberlogy.com` to `eryone3d.com`.

## Problem

Eryone is a separate Chinese 3D printing manufacturer — it is not related to Fiberlogy (a Polish company). The website was incorrectly set to `https://fiberlogy.com/`.

## Fix

Changed `data/eryone/brand.json` website to `https://eryone3d.com/`.

## Validation

Single-field change in a data file. No schema changes.