### PR TITLE
feat: expand AzureFilm coverage with 9 missing product lines

### DIFF
--- a/data/azurefilm/ABS/material.json
+++ b/data/azurefilm/ABS/material.json
@@ -1,0 +1,3 @@
+{
+  "material": "ABS"
+}

--- a/data/azurefilm/ABS/plus/black/sizes.json
+++ b/data/azurefilm/ABS/plus/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/black/variant.json
+++ b/data/azurefilm/ABS/plus/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#3F3F3F"
+}

--- a/data/azurefilm/ABS/plus/blue/sizes.json
+++ b/data/azurefilm/ABS/plus/blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/blue/variant.json
+++ b/data/azurefilm/ABS/plus/blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#457AB1"
+}

--- a/data/azurefilm/ABS/plus/filament.json
+++ b/data/azurefilm/ABS/plus/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "plus",
+  "name": "ABS Plus",
+  "diameter_tolerance": 0.02,
+  "density": 1.13,
+  "min_print_temperature": 250,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 110,
+  "max_bed_temperature": 110
+}

--- a/data/azurefilm/ABS/plus/glitter_black/sizes.json
+++ b/data/azurefilm/ABS/plus/glitter_black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/glitter_black/variant.json
+++ b/data/azurefilm/ABS/plus/glitter_black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "glitter_black",
+  "name": "Glitter Black",
+  "color_hex": "#3D3E39"
+}

--- a/data/azurefilm/ABS/plus/green/sizes.json
+++ b/data/azurefilm/ABS/plus/green/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/green/variant.json
+++ b/data/azurefilm/ABS/plus/green/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#5BA96C"
+}

--- a/data/azurefilm/ABS/plus/grey/sizes.json
+++ b/data/azurefilm/ABS/plus/grey/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/grey/variant.json
+++ b/data/azurefilm/ABS/plus/grey/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "grey",
+  "name": "Grey",
+  "color_hex": "#979DA4"
+}

--- a/data/azurefilm/ABS/plus/nature/sizes.json
+++ b/data/azurefilm/ABS/plus/nature/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/nature/variant.json
+++ b/data/azurefilm/ABS/plus/nature/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "nature",
+  "name": "Nature",
+  "color_hex": "#E4E3DF"
+}

--- a/data/azurefilm/ABS/plus/orange/sizes.json
+++ b/data/azurefilm/ABS/plus/orange/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/orange/variant.json
+++ b/data/azurefilm/ABS/plus/orange/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "orange",
+  "name": "Orange",
+  "color_hex": "#DE653D"
+}

--- a/data/azurefilm/ABS/plus/red/sizes.json
+++ b/data/azurefilm/ABS/plus/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/red/variant.json
+++ b/data/azurefilm/ABS/plus/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#D94A41"
+}

--- a/data/azurefilm/ABS/plus/white/sizes.json
+++ b/data/azurefilm/ABS/plus/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/white/variant.json
+++ b/data/azurefilm/ABS/plus/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#E6E8E7"
+}

--- a/data/azurefilm/ABS/plus/yellow/sizes.json
+++ b/data/azurefilm/ABS/plus/yellow/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/plus/yellow/variant.json
+++ b/data/azurefilm/ABS/plus/yellow/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#EED75B"
+}

--- a/data/azurefilm/ABS/prime/black/sizes.json
+++ b/data/azurefilm/ABS/prime/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/prime/black/variant.json
+++ b/data/azurefilm/ABS/prime/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#323232"
+}

--- a/data/azurefilm/ABS/prime/dark_blue/sizes.json
+++ b/data/azurefilm/ABS/prime/dark_blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/prime/dark_blue/variant.json
+++ b/data/azurefilm/ABS/prime/dark_blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "dark_blue",
+  "name": "Dark Blue",
+  "color_hex": "#4871AF"
+}

--- a/data/azurefilm/ABS/prime/filament.json
+++ b/data/azurefilm/ABS/prime/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "prime",
+  "name": "ABS Prime",
+  "diameter_tolerance": 0.02,
+  "density": 1.13,
+  "min_print_temperature": 250,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 90
+}

--- a/data/azurefilm/ABS/prime/red/sizes.json
+++ b/data/azurefilm/ABS/prime/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/prime/red/variant.json
+++ b/data/azurefilm/ABS/prime/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#DC4C43"
+}

--- a/data/azurefilm/ABS/prime/silver/sizes.json
+++ b/data/azurefilm/ABS/prime/silver/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/prime/silver/variant.json
+++ b/data/azurefilm/ABS/prime/silver/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "silver",
+  "name": "Silver",
+  "color_hex": "#9B999A"
+}

--- a/data/azurefilm/ABS/prime/white/sizes.json
+++ b/data/azurefilm/ABS/prime/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ABS/prime/white/variant.json
+++ b/data/azurefilm/ABS/prime/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#E5E5E5"
+}

--- a/data/azurefilm/ASA/material.json
+++ b/data/azurefilm/ASA/material.json
@@ -1,0 +1,3 @@
+{
+  "material": "ASA"
+}

--- a/data/azurefilm/ASA/original/black/sizes.json
+++ b/data/azurefilm/ASA/original/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/black/variant.json
+++ b/data/azurefilm/ASA/original/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#424344"
+}

--- a/data/azurefilm/ASA/original/blue/sizes.json
+++ b/data/azurefilm/ASA/original/blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/blue/variant.json
+++ b/data/azurefilm/ASA/original/blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#4B80B6"
+}

--- a/data/azurefilm/ASA/original/filament.json
+++ b/data/azurefilm/ASA/original/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "original",
+  "name": "ASA Original",
+  "diameter_tolerance": 0.02,
+  "density": 1.07,
+  "min_print_temperature": 250,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 100
+}

--- a/data/azurefilm/ASA/original/green/sizes.json
+++ b/data/azurefilm/ASA/original/green/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/green/variant.json
+++ b/data/azurefilm/ASA/original/green/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#5BA96C"
+}

--- a/data/azurefilm/ASA/original/grey/sizes.json
+++ b/data/azurefilm/ASA/original/grey/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/grey/variant.json
+++ b/data/azurefilm/ASA/original/grey/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "grey",
+  "name": "Grey",
+  "color_hex": "#7A7976"
+}

--- a/data/azurefilm/ASA/original/natural/sizes.json
+++ b/data/azurefilm/ASA/original/natural/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/natural/variant.json
+++ b/data/azurefilm/ASA/original/natural/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "natural",
+  "name": "Natural",
+  "color_hex": "#E3E2DE"
+}

--- a/data/azurefilm/ASA/original/orange/sizes.json
+++ b/data/azurefilm/ASA/original/orange/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/orange/variant.json
+++ b/data/azurefilm/ASA/original/orange/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "orange",
+  "name": "Orange",
+  "color_hex": "#DF6B40"
+}

--- a/data/azurefilm/ASA/original/red/sizes.json
+++ b/data/azurefilm/ASA/original/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/red/variant.json
+++ b/data/azurefilm/ASA/original/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#D94B43"
+}

--- a/data/azurefilm/ASA/original/silver/sizes.json
+++ b/data/azurefilm/ASA/original/silver/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/silver/variant.json
+++ b/data/azurefilm/ASA/original/silver/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "silver",
+  "name": "Silver",
+  "color_hex": "#979797"
+}

--- a/data/azurefilm/ASA/original/white/sizes.json
+++ b/data/azurefilm/ASA/original/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/white/variant.json
+++ b/data/azurefilm/ASA/original/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#E4E4E4"
+}

--- a/data/azurefilm/ASA/original/yellow/sizes.json
+++ b/data/azurefilm/ASA/original/yellow/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/original/yellow/variant.json
+++ b/data/azurefilm/ASA/original/yellow/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#EFD75C"
+}

--- a/data/azurefilm/ASA/prime/black/sizes.json
+++ b/data/azurefilm/ASA/prime/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/prime/black/variant.json
+++ b/data/azurefilm/ASA/prime/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#373737"
+}

--- a/data/azurefilm/ASA/prime/dark_blue/sizes.json
+++ b/data/azurefilm/ASA/prime/dark_blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/prime/dark_blue/variant.json
+++ b/data/azurefilm/ASA/prime/dark_blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "dark_blue",
+  "name": "Dark Blue",
+  "color_hex": "#456DAD"
+}

--- a/data/azurefilm/ASA/prime/filament.json
+++ b/data/azurefilm/ASA/prime/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "prime",
+  "name": "ASA Prime",
+  "diameter_tolerance": 0.02,
+  "density": 1.15,
+  "min_print_temperature": 245,
+  "max_print_temperature": 245,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 90
+}

--- a/data/azurefilm/ASA/prime/red/sizes.json
+++ b/data/azurefilm/ASA/prime/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/prime/red/variant.json
+++ b/data/azurefilm/ASA/prime/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#DB4940"
+}

--- a/data/azurefilm/ASA/prime/silver/sizes.json
+++ b/data/azurefilm/ASA/prime/silver/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/prime/silver/variant.json
+++ b/data/azurefilm/ASA/prime/silver/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "silver",
+  "name": "Silver",
+  "color_hex": "#999999"
+}

--- a/data/azurefilm/ASA/prime/white/sizes.json
+++ b/data/azurefilm/ASA/prime/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/ASA/prime/white/variant.json
+++ b/data/azurefilm/ASA/prime/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#EFEFEF"
+}

--- a/data/azurefilm/PC/material.json
+++ b/data/azurefilm/PC/material.json
@@ -1,0 +1,3 @@
+{
+  "material": "PC"
+}

--- a/data/azurefilm/PC/pc_abs/black/sizes.json
+++ b/data/azurefilm/PC/pc_abs/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PC/pc_abs/black/variant.json
+++ b/data/azurefilm/PC/pc_abs/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#2D2C32"
+}

--- a/data/azurefilm/PC/pc_abs/filament.json
+++ b/data/azurefilm/PC/pc_abs/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "pc_abs",
+  "name": "PC-ABS",
+  "diameter_tolerance": 0.02,
+  "density": 1.04,
+  "min_print_temperature": 270,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 110,
+  "max_bed_temperature": 110
+}

--- a/data/azurefilm/PC/pc_abs/natur/sizes.json
+++ b/data/azurefilm/PC/pc_abs/natur/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PC/pc_abs/natur/variant.json
+++ b/data/azurefilm/PC/pc_abs/natur/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "natur",
+  "name": "Natur",
+  "color_hex": "#FEFFFB"
+}

--- a/data/azurefilm/PC/pc_abs/white/sizes.json
+++ b/data/azurefilm/PC/pc_abs/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PC/pc_abs/white/variant.json
+++ b/data/azurefilm/PC/pc_abs/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#E8E8E8"
+}

--- a/data/azurefilm/PCTG/material.json
+++ b/data/azurefilm/PCTG/material.json
@@ -1,0 +1,3 @@
+{
+  "material": "PCTG"
+}

--- a/data/azurefilm/PCTG/pctg/black/sizes.json
+++ b/data/azurefilm/PCTG/pctg/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PCTG/pctg/black/variant.json
+++ b/data/azurefilm/PCTG/pctg/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#3D3D3D"
+}

--- a/data/azurefilm/PCTG/pctg/filament.json
+++ b/data/azurefilm/PCTG/pctg/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "pctg",
+  "name": "PCTG",
+  "diameter_tolerance": 0.02,
+  "density": 1.29,
+  "min_print_temperature": 250,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
+}

--- a/data/azurefilm/PCTG/pctg/grey/sizes.json
+++ b/data/azurefilm/PCTG/pctg/grey/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PCTG/pctg/grey/variant.json
+++ b/data/azurefilm/PCTG/pctg/grey/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "grey",
+  "name": "Grey",
+  "color_hex": "#757470"
+}

--- a/data/azurefilm/PCTG/pctg/transparent/sizes.json
+++ b/data/azurefilm/PCTG/pctg/transparent/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PCTG/pctg/transparent/variant.json
+++ b/data/azurefilm/PCTG/pctg/transparent/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "transparent",
+  "name": "Transparent",
+  "color_hex": "#D5D4DA"
+}

--- a/data/azurefilm/PCTG/pctg/white/sizes.json
+++ b/data/azurefilm/PCTG/pctg/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PCTG/pctg/white/variant.json
+++ b/data/azurefilm/PCTG/pctg/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#E8E8E8"
+}

--- a/data/azurefilm/PLA/glitter_pla/black/sizes.json
+++ b/data/azurefilm/PLA/glitter_pla/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/glitter_pla/black/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#3E3F39"
+}

--- a/data/azurefilm/PLA/glitter_pla/blue/sizes.json
+++ b/data/azurefilm/PLA/glitter_pla/blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/glitter_pla/blue/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#40468E"
+}

--- a/data/azurefilm/PLA/glitter_pla/filament.json
+++ b/data/azurefilm/PLA/glitter_pla/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "glitter_pla",
+  "name": "Glitter PLA",
+  "diameter_tolerance": 0.02,
+  "density": 1.24,
+  "min_print_temperature": 225,
+  "max_print_temperature": 225,
+  "min_bed_temperature": 55,
+  "max_bed_temperature": 55
+}

--- a/data/azurefilm/PLA/glitter_pla/green/sizes.json
+++ b/data/azurefilm/PLA/glitter_pla/green/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/glitter_pla/green/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/green/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#4D8967"
+}

--- a/data/azurefilm/PLA/glitter_pla/nature/sizes.json
+++ b/data/azurefilm/PLA/glitter_pla/nature/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/glitter_pla/nature/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/nature/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "nature",
+  "name": "Nature",
+  "color_hex": "#C3C9C2"
+}

--- a/data/azurefilm/PLA/glitter_pla/red/sizes.json
+++ b/data/azurefilm/PLA/glitter_pla/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/glitter_pla/red/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#8C363A"
+}

--- a/data/azurefilm/PLA/glitter_pla/white/sizes.json
+++ b/data/azurefilm/PLA/glitter_pla/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/glitter_pla/white/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#F9F9F9"
+}

--- a/data/azurefilm/PLA/prime_pla/black/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/black/variant.json
+++ b/data/azurefilm/PLA/prime_pla/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#303030"
+}

--- a/data/azurefilm/PLA/prime_pla/dark_blue/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/dark_blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/dark_blue/variant.json
+++ b/data/azurefilm/PLA/prime_pla/dark_blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "dark_blue",
+  "name": "Dark Blue",
+  "color_hex": "#284773"
+}

--- a/data/azurefilm/PLA/prime_pla/dark_grey/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/dark_grey/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/dark_grey/variant.json
+++ b/data/azurefilm/PLA/prime_pla/dark_grey/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "dark_grey",
+  "name": "Dark Grey",
+  "color_hex": "#787774"
+}

--- a/data/azurefilm/PLA/prime_pla/filament.json
+++ b/data/azurefilm/PLA/prime_pla/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "prime_pla",
+  "name": "PLA Prime",
+  "diameter_tolerance": 0.02,
+  "density": 1.27,
+  "min_print_temperature": 230,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 60
+}

--- a/data/azurefilm/PLA/prime_pla/light_grey/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/light_grey/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/light_grey/variant.json
+++ b/data/azurefilm/PLA/prime_pla/light_grey/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "light_grey",
+  "name": "Light Grey",
+  "color_hex": "#959CA2"
+}

--- a/data/azurefilm/PLA/prime_pla/nature/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/nature/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/nature/variant.json
+++ b/data/azurefilm/PLA/prime_pla/nature/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "nature",
+  "name": "Nature",
+  "color_hex": "#E8E7E2"
+}

--- a/data/azurefilm/PLA/prime_pla/red/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/red/variant.json
+++ b/data/azurefilm/PLA/prime_pla/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#D14137"
+}

--- a/data/azurefilm/PLA/prime_pla/white/sizes.json
+++ b/data/azurefilm/PLA/prime_pla/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/PLA/prime_pla/white/variant.json
+++ b/data/azurefilm/PLA/prime_pla/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#E4E4E4"
+}

--- a/data/azurefilm/TPU/tpu_85a/black/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/black/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/black/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#101313"
+}

--- a/data/azurefilm/TPU/tpu_85a/blue/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/blue/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/blue/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/blue/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#4059A6"
+}

--- a/data/azurefilm/TPU/tpu_85a/filament.json
+++ b/data/azurefilm/TPU/tpu_85a/filament.json
@@ -1,0 +1,11 @@
+{
+  "id": "tpu_85a",
+  "name": "TPU 85A",
+  "diameter_tolerance": 0.02,
+  "density": 1.12,
+  "min_print_temperature": 230,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 60,
+  "shore_hardness_a": 85
+}

--- a/data/azurefilm/TPU/tpu_85a/neon_green/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/neon_green/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/neon_green/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/neon_green/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "neon_green",
+  "name": "Neon Green",
+  "color_hex": "#7CBA56"
+}

--- a/data/azurefilm/TPU/tpu_85a/neon_orange/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/neon_orange/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/neon_orange/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/neon_orange/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "neon_orange",
+  "name": "Neon Orange",
+  "color_hex": "#EAA150"
+}

--- a/data/azurefilm/TPU/tpu_85a/neon_yellow/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/neon_yellow/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/neon_yellow/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/neon_yellow/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "neon_yellow",
+  "name": "Neon Yellow",
+  "color_hex": "#D1DD5E"
+}

--- a/data/azurefilm/TPU/tpu_85a/red/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/red/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/red/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#BC3635"
+}

--- a/data/azurefilm/TPU/tpu_85a/transparent/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/transparent/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/transparent/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/transparent/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "transparent",
+  "name": "Transparent",
+  "color_hex": "#EBEEEF"
+}

--- a/data/azurefilm/TPU/tpu_85a/white/sizes.json
+++ b/data/azurefilm/TPU/tpu_85a/white/sizes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "empty_spool_weight": 164
+  }
+]

--- a/data/azurefilm/TPU/tpu_85a/white/variant.json
+++ b/data/azurefilm/TPU/tpu_85a/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#EDF6F2"
+}


### PR DESCRIPTION
## Summary

Expands AzureFilm filament coverage by adding 9 product lines that were missing from the database.

## Changes

- 129 files changed, 799 insertions
- Adds missing AzureFilm filament variants across multiple material types including TPU

## Validation\n\nAll data follows the existing schema format and naming conventions.