### PR TITLE
feat: expand TINMORRY with ABS material category

### DIFF
--- a/data/tinmorry/ABS/abs_pro/black/sizes.json
+++ b/data/tinmorry/ABS/abs_pro/black/sizes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75
+  }
+]

--- a/data/tinmorry/ABS/abs_pro/black/variant.json
+++ b/data/tinmorry/ABS/abs_pro/black/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000"
+}

--- a/data/tinmorry/ABS/abs_pro/filament.json
+++ b/data/tinmorry/ABS/abs_pro/filament.json
@@ -1,0 +1,10 @@
+{
+  "id": "abs_pro",
+  "name": "ABS Pro",
+  "diameter_tolerance": 0.02,
+  "density": 1.04,
+  "min_print_temperature": 220,
+  "max_print_temperature": 260,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
+}

--- a/data/tinmorry/ABS/abs_pro/gray/sizes.json
+++ b/data/tinmorry/ABS/abs_pro/gray/sizes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75
+  }
+]

--- a/data/tinmorry/ABS/abs_pro/gray/variant.json
+++ b/data/tinmorry/ABS/abs_pro/gray/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "gray",
+  "name": "Gray",
+  "color_hex": "#808080"
+}

--- a/data/tinmorry/ABS/abs_pro/red/sizes.json
+++ b/data/tinmorry/ABS/abs_pro/red/sizes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75
+  }
+]

--- a/data/tinmorry/ABS/abs_pro/red/variant.json
+++ b/data/tinmorry/ABS/abs_pro/red/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#FF0000"
+}

--- a/data/tinmorry/ABS/abs_pro/white/sizes.json
+++ b/data/tinmorry/ABS/abs_pro/white/sizes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75
+  }
+]

--- a/data/tinmorry/ABS/abs_pro/white/variant.json
+++ b/data/tinmorry/ABS/abs_pro/white/variant.json
@@ -1,0 +1,5 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF"
+}

--- a/data/tinmorry/ABS/material.json
+++ b/data/tinmorry/ABS/material.json
@@ -1,0 +1,3 @@
+{
+  "material": "ABS"
+}


### PR DESCRIPTION
## Expand Existing Brand: TINMORRY

Add missing ABS material category to the existing TINMORRY brand.

### Added
| Filament | Colors | Nozzle Temp | Bed Temp | Density |
|----------|--------|-------------|----------|---------|
| ABS Pro | 4 (black, white, gray, red) | 220-260°C | 90-110°C | 1.04 |

### Details
- TINMORRY already has 7 material categories (ASA, PA6, PET, PETG, PLA, PP, TPU)
- This PR adds the missing **ABS** category
- **10 files** added
- Follows existing TINMORRY file format conventions

### Checklist
- [x] material.json for ABS
- [x] filament.json with correct temps and density
- [x] variant.json for each color with hex codes
- [x] sizes.json for each variant (1kg/1.75mm)