### PR TITLE
fix: add missing traits to 22 Network filament variants

### DIFF
--- a/data/22_network/PLA/silk_pla/rainbow/variant.json
+++ b/data/22_network/PLA/silk_pla/rainbow/variant.json
@@ -3,7 +3,8 @@
   "name": "Rainbow",
   "color_hex": "#FF0000",
   "traits": {
-    "silk": true,
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/22_network/PLA/silk_pla/tri_candy_rainbow/variant.json
+++ b/data/22_network/PLA/silk_pla/tri_candy_rainbow/variant.json
@@ -3,7 +3,8 @@
   "name": "Tri Candy Rainbow",
   "color_hex": "#FF69B4",
   "traits": {
-    "silk": true,
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/22_network/PLA/silk_pla/universe_rainbow/variant.json
+++ b/data/22_network/PLA/silk_pla/universe_rainbow/variant.json
@@ -3,7 +3,8 @@
   "name": "Universe Rainbow",
   "color_hex": "#4B0082",
   "traits": {
-    "silk": true,
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true,
+    "silk": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 3 22 Network filament variant(s).

Add missing `iridescent` trait to silk rainbow variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
