### PR TITLE
fix: add missing traits to Aceaddity filament variants

### DIFF
--- a/data/aceaddity/PLA/marble_pla/marble/variant.json
+++ b/data/aceaddity/PLA/marble_pla/marble/variant.json
@@ -3,6 +3,7 @@
   "name": "Marble",
   "color_hex": "#ADB4B9",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 1 Aceaddity filament variant(s).

Add missing `imitates_stone` trait to marble PLA variant.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
