### PR TITLE
fix: add missing traits to Ambrosia filament variants

### DIFF
--- a/data/ambrosia/ABS/matte/black/variant.json
+++ b/data/ambrosia/ABS/matte/black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "black",
   "name": "Black",
-  "color_hex": "#25282A"
+  "color_hex": "#25282A",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/ambrosia/ABS/matte/british_racing_green/variant.json
+++ b/data/ambrosia/ABS/matte/british_racing_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "british_racing_green",
   "name": "British Racing Green",
-  "color_hex": "#2D6467"
+  "color_hex": "#2D6467",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/ambrosia/ABS/matte/galactic_black/variant.json
+++ b/data/ambrosia/ABS/matte/galactic_black/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "galactic_black",
   "name": "Galactic Black",
-  "color_hex": "#454546"
+  "color_hex": "#454546",
+  "traits": {
+    "glitter": true,
+    "matte": true
+  }
 }

--- a/data/ambrosia/ABS/matte/grey_abyss/variant.json
+++ b/data/ambrosia/ABS/matte/grey_abyss/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "grey_abyss",
   "name": "Grey Abyss",
-  "color_hex": "#4B4747"
+  "color_hex": "#4B4747",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/ambrosia/ABS/matte/hot_pink/variant.json
+++ b/data/ambrosia/ABS/matte/hot_pink/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "hot_pink",
   "name": "Hot Pink",
-  "color_hex": "#FA008A"
+  "color_hex": "#FA008A",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/ambrosia/ABS/matte/voron_red/variant.json
+++ b/data/ambrosia/ABS/matte/voron_red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "voron_red",
   "name": "Voron Red",
-  "color_hex": "#A12336"
+  "color_hex": "#A12336",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/ambrosia/ASA/cf/black/variant.json
+++ b/data/ambrosia/ASA/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "black",
   "name": "Black",
-  "color_hex": "#000000"
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/cf/dark_blue/variant.json
+++ b/data/ambrosia/ASA/cf/dark_blue/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "dark_blue",
   "name": "Dark Blue",
-  "color_hex": "#454A56"
+  "color_hex": "#454A56",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/cf/dark_red/variant.json
+++ b/data/ambrosia/ASA/cf/dark_red/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "dark_red",
   "name": "Dark Red",
-  "color_hex": "#4C3B3B"
+  "color_hex": "#4C3B3B",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/cf/grey/variant.json
+++ b/data/ambrosia/ASA/cf/grey/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "grey",
   "name": "Grey",
-  "color_hex": "#5B6670"
+  "color_hex": "#5B6670",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/cf/purple/variant.json
+++ b/data/ambrosia/ASA/cf/purple/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "purple",
   "name": "Purple",
-  "color_hex": "#5E4690"
+  "color_hex": "#5E4690",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/dolos/banana_rama/variant.json
+++ b/data/ambrosia/ASA/dolos/banana_rama/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "banana_rama",
   "name": "Banana Rama",
-  "color_hex": "#F2C987"
+  "color_hex": "#F2C987",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/ASA/dolos/cool_grey_pearl/variant.json
+++ b/data/ambrosia/ASA/dolos/cool_grey_pearl/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "cool_grey_pearl",
   "name": "Cool Grey Pearl",
-  "color_hex": "#B9B3B5"
+  "color_hex": "#B9B3B5",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/ASA/dolos/prince_of_purple/variant.json
+++ b/data/ambrosia/ASA/dolos/prince_of_purple/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "prince_of_purple",
   "name": "Prince of Purple",
-  "color_hex": "#A368D5"
+  "color_hex": "#A368D5",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/ASA/dolos/titanium_anno/variant.json
+++ b/data/ambrosia/ASA/dolos/titanium_anno/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "titanium_anno",
   "name": "Titanium Anno",
-  "color_hex": "#2B3E63"
+  "color_hex": "#2B3E63",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/ASA/dolos/violet_void/variant.json
+++ b/data/ambrosia/ASA/dolos/violet_void/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "violet_void",
   "name": "Violet Void",
-  "color_hex": "#502747"
+  "color_hex": "#502747",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/armored_turtle_green/variant.json
+++ b/data/ambrosia/ASA/galactic/armored_turtle_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "armored_turtle_green",
   "name": "Armored Turtle Green",
-  "color_hex": "#0E945B"
+  "color_hex": "#0E945B",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/black_multi_color_glitter/variant.json
+++ b/data/ambrosia/ASA/galactic/black_multi_color_glitter/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "black_multi_color_glitter",
   "name": "Black Multi Color Glitter",
-  "color_hex": "#000000"
+  "color_hex": "#000000",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_black/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_black",
   "name": "Galactic Black",
-  "color_hex": "#352F38"
+  "color_hex": "#352F38",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_glow/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_glow/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "galactic_glow",
   "name": "Galactic Glow",
-  "color_hex": "#00ED60"
+  "color_hex": "#00ED60",
+  "traits": {
+    "glitter": true,
+    "glow": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_grape/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_grape/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_grape",
   "name": "Galactic Grape",
-  "color_hex": "#A82A82"
+  "color_hex": "#A82A82",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_green/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_green",
   "name": "Galactic Green",
-  "color_hex": "#0AF53D"
+  "color_hex": "#0AF53D",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_grey/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_grey/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_grey",
   "name": "Galactic Grey",
-  "color_hex": "#79797B"
+  "color_hex": "#79797B",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_holiday_green/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_holiday_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_holiday_green",
   "name": "Galactic Holiday Green",
-  "color_hex": "#C8D639"
+  "color_hex": "#C8D639",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_holiday_red/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_holiday_red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_holiday_red",
   "name": "Galactic Holiday Red",
-  "color_hex": "#EF2D1D"
+  "color_hex": "#EF2D1D",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_hot_pink/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_hot_pink/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_hot_pink",
   "name": "Galactic Hot Pink",
-  "color_hex": "#FF3486"
+  "color_hex": "#FF3486",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_midnight_meteorite/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_midnight_meteorite/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_midnight_meteorite",
   "name": "Galactic Midnight Meteorite",
-  "color_hex": "#40298E"
+  "color_hex": "#40298E",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_pink/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_pink/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_pink",
   "name": "Galactic Pink",
-  "color_hex": "#FF54AE"
+  "color_hex": "#FF54AE",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_planetary_blue/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_planetary_blue/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_planetary_blue",
   "name": "Galactic Planetary Blue",
-  "color_hex": "#23ADE9"
+  "color_hex": "#23ADE9",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_quadra_teal/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_quadra_teal/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_quadra_teal",
   "name": "Galactic Quadra Teal",
-  "color_hex": "#22AAC9"
+  "color_hex": "#22AAC9",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_santa_s_robe/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_santa_s_robe/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_santa_s_robe",
   "name": "Galactic Santa's Robe",
-  "color_hex": "#FC3629"
+  "color_hex": "#FC3629",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_super_blue/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_super_blue/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_super_blue",
   "name": "Galactic Super Blue",
-  "color_hex": "#2055E0"
+  "color_hex": "#2055E0",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_super_red/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_super_red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_super_red",
   "name": "Galactic Super Red",
-  "color_hex": "#EE3329"
+  "color_hex": "#EE3329",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_voron_red/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_voron_red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_voron_red",
   "name": "Galactic Voron Red",
-  "color_hex": "#BC2421"
+  "color_hex": "#BC2421",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/galactic_yellow/variant.json
+++ b/data/ambrosia/ASA/galactic/galactic_yellow/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_yellow",
   "name": "Galactic Yellow",
-  "color_hex": "#D2DC22"
+  "color_hex": "#D2DC22",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/skin_rash_light/variant.json
+++ b/data/ambrosia/ASA/galactic/skin_rash_light/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "skin_rash_light",
   "name": "Skin Rash (Light)",
-  "color_hex": "#CE9E7E"
+  "color_hex": "#CE9E7E",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/galactic/supernova_black/variant.json
+++ b/data/ambrosia/ASA/galactic/supernova_black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "supernova_black",
   "name": "Supernova Black",
-  "color_hex": "#2A292E"
+  "color_hex": "#2A292E",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/ASA/gf/black/variant.json
+++ b/data/ambrosia/ASA/gf/black/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "black",
   "name": "Black",
-  "color_hex": "#000000"
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/gf/natural/variant.json
+++ b/data/ambrosia/ASA/gf/natural/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "natural",
   "name": "Natural",
-  "color_hex": "#E0D9CD"
+  "color_hex": "#E0D9CD",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/gf/voron_red/variant.json
+++ b/data/ambrosia/ASA/gf/voron_red/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "voron_red",
   "name": "Voron Red",
-  "color_hex": "#A12336"
+  "color_hex": "#A12336",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/ambrosia/ASA/standard/fluorescent_neon_green/variant.json
+++ b/data/ambrosia/ASA/standard/fluorescent_neon_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "fluorescent_neon_green",
   "name": "Fluorescent Neon Green",
-  "color_hex": "#53D132"
+  "color_hex": "#53D132",
+  "traits": {
+    "neon": true
+  }
 }

--- a/data/ambrosia/PC/cf/black/variant.json
+++ b/data/ambrosia/PC/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "black",
   "name": "Black",
-  "color_hex": "#000000"
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/PC/cf/blue/variant.json
+++ b/data/ambrosia/PC/cf/blue/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "blue",
   "name": "Blue",
-  "color_hex": "#2C5C8F"
+  "color_hex": "#2C5C8F",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/PC/cf/red/variant.json
+++ b/data/ambrosia/PC/cf/red/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "red",
   "name": "Red",
-  "color_hex": "#F12D43"
+  "color_hex": "#F12D43",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/PC/cf/white/variant.json
+++ b/data/ambrosia/PC/cf/white/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "white",
   "name": "White",
-  "color_hex": "#FFFFFF"
+  "color_hex": "#FFFFFF",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/ambrosia/PC/pc_abs/galactic_black/variant.json
+++ b/data/ambrosia/PC/pc_abs/galactic_black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_black",
   "name": "Galactic Black",
-  "color_hex": "#000002"
+  "color_hex": "#000002",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PC/pc_abs/galactic_grey/variant.json
+++ b/data/ambrosia/PC/pc_abs/galactic_grey/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_grey",
   "name": "Galactic Grey",
-  "color_hex": "#79797B"
+  "color_hex": "#79797B",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PETG/standard/clear/variant.json
+++ b/data/ambrosia/PETG/standard/clear/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "clear",
   "name": "Clear",
-  "color_hex": "#FFFFFF"
+  "color_hex": "#FFFFFF",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/ambrosia/PLA/dolos/banana_rama/variant.json
+++ b/data/ambrosia/PLA/dolos/banana_rama/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "banana_rama",
   "name": "Banana Rama",
-  "color_hex": "#F2C987"
+  "color_hex": "#F2C987",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/PLA/dolos/cool_grey_pearl/variant.json
+++ b/data/ambrosia/PLA/dolos/cool_grey_pearl/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "cool_grey_pearl",
   "name": "Cool Grey Pearl",
-  "color_hex": "#B9B3B5"
+  "color_hex": "#B9B3B5",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/PLA/dolos/prince_of_purple/variant.json
+++ b/data/ambrosia/PLA/dolos/prince_of_purple/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "prince_of_purple",
   "name": "Prince of Purple",
-  "color_hex": "#A368D5"
+  "color_hex": "#A368D5",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/PLA/dolos/titanium_anno/variant.json
+++ b/data/ambrosia/PLA/dolos/titanium_anno/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "titanium_anno",
   "name": "Titanium Anno",
-  "color_hex": "#2B3E63"
+  "color_hex": "#2B3E63",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/PLA/dolos/violet_void/variant.json
+++ b/data/ambrosia/PLA/dolos/violet_void/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "violet_void",
   "name": "Violet Void",
-  "color_hex": "#502747"
+  "color_hex": "#502747",
+  "traits": {
+    "coextruded": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/armored_turtle_green/variant.json
+++ b/data/ambrosia/PLA/galactic/armored_turtle_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "armored_turtle_green",
   "name": "Armored Turtle Green",
-  "color_hex": "#0E945B"
+  "color_hex": "#0E945B",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_glow_blue/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_glow_blue/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "galactic_glow_blue",
   "name": "Galactic Glow Blue",
-  "color_hex": "#09D6EB"
+  "color_hex": "#09D6EB",
+  "traits": {
+    "glitter": true,
+    "glow": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_glow_green/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_glow_green/variant.json
@@ -1,5 +1,9 @@
 {
   "id": "galactic_glow_green",
   "name": "Galactic Glow Green",
-  "color_hex": "#00ED60"
+  "color_hex": "#00ED60",
+  "traits": {
+    "glitter": true,
+    "glow": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_grape/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_grape/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_grape",
   "name": "Galactic Grape",
-  "color_hex": "#A82A82"
+  "color_hex": "#A82A82",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_green/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_green",
   "name": "Galactic Green",
-  "color_hex": "#0AF53D"
+  "color_hex": "#0AF53D",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_grey/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_grey/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_grey",
   "name": "Galactic Grey",
-  "color_hex": "#79797B"
+  "color_hex": "#79797B",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_hot_pink/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_hot_pink/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_hot_pink",
   "name": "Galactic Hot Pink",
-  "color_hex": "#FA008A"
+  "color_hex": "#FA008A",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_midnight_meteorite/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_midnight_meteorite/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_midnight_meteorite",
   "name": "Galactic Midnight Meteorite",
-  "color_hex": "#40298E"
+  "color_hex": "#40298E",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_pink/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_pink/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_pink",
   "name": "Galactic Pink",
-  "color_hex": "#FF54AE"
+  "color_hex": "#FF54AE",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_planetary_blue/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_planetary_blue/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_planetary_blue",
   "name": "Galactic Planetary Blue",
-  "color_hex": "#23ADE9"
+  "color_hex": "#23ADE9",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_quadra_teal/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_quadra_teal/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_quadra_teal",
   "name": "Galactic Quadra Teal",
-  "color_hex": "#009CA6"
+  "color_hex": "#009CA6",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_super_blue/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_super_blue/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_super_blue",
   "name": "Galactic Super Blue",
-  "color_hex": "#2055E0"
+  "color_hex": "#2055E0",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_velvet_black/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_velvet_black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_velvet_black",
   "name": "Galactic Velvet Black",
-  "color_hex": "#000000"
+  "color_hex": "#000000",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_voron_red/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_voron_red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_voron_red",
   "name": "Galactic Voron Red",
-  "color_hex": "#BC2421"
+  "color_hex": "#BC2421",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/galactic_yellow/variant.json
+++ b/data/ambrosia/PLA/galactic/galactic_yellow/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "galactic_yellow",
   "name": "Galactic Yellow",
-  "color_hex": "#D2DC22"
+  "color_hex": "#D2DC22",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/holiday_green/variant.json
+++ b/data/ambrosia/PLA/galactic/holiday_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "holiday_green",
   "name": "Holiday Green",
-  "color_hex": "#C8D639"
+  "color_hex": "#C8D639",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/holiday_red/variant.json
+++ b/data/ambrosia/PLA/galactic/holiday_red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "holiday_red",
   "name": "Holiday Red",
-  "color_hex": "#EF2D1D"
+  "color_hex": "#EF2D1D",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/santa_s_robe/variant.json
+++ b/data/ambrosia/PLA/galactic/santa_s_robe/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "santa_s_robe",
   "name": "Santa's Robe",
-  "color_hex": "#FC3629"
+  "color_hex": "#FC3629",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/galactic/supernova_black/variant.json
+++ b/data/ambrosia/PLA/galactic/supernova_black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "supernova_black",
   "name": "Supernova Black",
-  "color_hex": "#2A292E"
+  "color_hex": "#2A292E",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/ambrosia/PLA/pla/fluorescent_neon_green/variant.json
+++ b/data/ambrosia/PLA/pla/fluorescent_neon_green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "fluorescent_neon_green",
   "name": "Fluorescent Neon Green",
-  "color_hex": "#53D132"
+  "color_hex": "#53D132",
+  "traits": {
+    "neon": true
+  }
 }

--- a/data/ambrosia/PLA/silk/bright_gold/variant.json
+++ b/data/ambrosia/PLA/silk/bright_gold/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "bright_gold",
   "name": "Bright Gold",
-  "color_hex": "#FAC33A"
+  "color_hex": "#FAC33A",
+  "traits": {
+    "silk": true
+  }
 }

--- a/data/ambrosia/PLA/silk/metal_grey/variant.json
+++ b/data/ambrosia/PLA/silk/metal_grey/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "metal_grey",
   "name": "Metal Grey",
-  "color_hex": "#5B585A"
+  "color_hex": "#5B585A",
+  "traits": {
+    "silk": true
+  }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 75 Ambrosia filament variant(s).

Add missing traits including `contains_carbon_fiber`, `contains_glass_fiber`, `abrasive`, `matte`, `silk`, `glitter`, `coextruded`, `glow`, `neon`, and `translucent` to applicable variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
