### PR TITLE
fix: add missing traits to AzureFilm filament variants

### DIFF
--- a/data/azurefilm/ABS/plus/glitter_black/variant.json
+++ b/data/azurefilm/ABS/plus/glitter_black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "glitter_black",
   "name": "Glitter Black",
-  "color_hex": "#3D3E39"
+  "color_hex": "#3D3E39",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PA6/carbonfiber_nylon/black/variant.json
+++ b/data/azurefilm/PA6/carbonfiber_nylon/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/azurefilm/PET/carbonfiber_pet/black/variant.json
+++ b/data/azurefilm/PET/carbonfiber_pet/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/azurefilm/PLA/glitter_pla/black/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/black/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "black",
   "name": "Black",
-  "color_hex": "#3E3F39"
+  "color_hex": "#3E3F39",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/glitter_pla/blue/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/blue/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "blue",
   "name": "Blue",
-  "color_hex": "#40468E"
+  "color_hex": "#40468E",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/glitter_pla/green/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/green/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "green",
   "name": "Green",
-  "color_hex": "#4D8967"
+  "color_hex": "#4D8967",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/glitter_pla/nature/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/nature/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "nature",
   "name": "Nature",
-  "color_hex": "#C3C9C2"
+  "color_hex": "#C3C9C2",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/glitter_pla/red/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/red/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "red",
   "name": "Red",
-  "color_hex": "#8C363A"
+  "color_hex": "#8C363A",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/glitter_pla/white/variant.json
+++ b/data/azurefilm/PLA/glitter_pla/white/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "white",
   "name": "White",
-  "color_hex": "#F9F9F9"
+  "color_hex": "#F9F9F9",
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/pla/black_glitter/variant.json
+++ b/data/azurefilm/PLA/pla/black_glitter/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "black_glitter",
-    "name": "Black glitter",
-    "color_hex": "#121212",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "black_glitter",
+  "name": "Black glitter",
+  "color_hex": "#121212",
+  "traits": {
+    "glitter": true,
+    "recyclable": true
+  }
 }

--- a/data/azurefilm/PLA/pla/blue_glitter/variant.json
+++ b/data/azurefilm/PLA/pla/blue_glitter/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "blue_glitter",
-    "name": "Blue glitter",
-    "color_hex": "#1a3095",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "blue_glitter",
+  "name": "Blue glitter",
+  "color_hex": "#1a3095",
+  "traits": {
+    "glitter": true,
+    "recyclable": true
+  }
 }

--- a/data/azurefilm/PLA/pla/galaxy_black/variant.json
+++ b/data/azurefilm/PLA/pla/galaxy_black/variant.json
@@ -3,5 +3,8 @@
   "name": "Galaxy Black",
   "color_hex": [
     "#000000"
-  ]
+  ],
+  "traits": {
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/pla/green_glitter/variant.json
+++ b/data/azurefilm/PLA/pla/green_glitter/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "green_glitter",
-    "name": "Green glitter",
-    "color_hex": "#41904e",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "green_glitter",
+  "name": "Green glitter",
+  "color_hex": "#41904e",
+  "traits": {
+    "glitter": true,
+    "recyclable": true
+  }
 }

--- a/data/azurefilm/PLA/pla/neutral_glitter/variant.json
+++ b/data/azurefilm/PLA/pla/neutral_glitter/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "neutral_glitter",
-    "name": "Neutral glitter",
-    "color_hex": "#f5f5f5",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "neutral_glitter",
+  "name": "Neutral glitter",
+  "color_hex": "#f5f5f5",
+  "traits": {
+    "glitter": true,
+    "recyclable": true
+  }
 }

--- a/data/azurefilm/PLA/pla/red_glitter/variant.json
+++ b/data/azurefilm/PLA/pla/red_glitter/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "red_glitter",
-    "name": "Red glitter",
-    "color_hex": "#931924",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "red_glitter",
+  "name": "Red glitter",
+  "color_hex": "#931924",
+  "traits": {
+    "glitter": true,
+    "recyclable": true
+  }
 }

--- a/data/azurefilm/PLA/pla/white_glitter/variant.json
+++ b/data/azurefilm/PLA/pla/white_glitter/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "white_glitter",
-    "name": "White glitter",
-    "color_hex": "#ffffff",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "white_glitter",
+  "name": "White glitter",
+  "color_hex": "#ffffff",
+  "traits": {
+    "glitter": true,
+    "recyclable": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/army_green/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/army_green/variant.json
@@ -3,5 +3,8 @@
   "name": "Army Green",
   "color_hex": [
     "#656545"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/black/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/black/variant.json
@@ -3,5 +3,8 @@
   "name": "Black",
   "color_hex": [
     "#000000"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/blue/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/blue/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "blue",
   "name": "Blue",
-  "color_hex": "#2B8DA7"
+  "color_hex": "#2B8DA7",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/bordeaux/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/bordeaux/variant.json
@@ -3,5 +3,8 @@
   "name": "Bordeaux",
   "color_hex": [
     "#844C54"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/coral/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/coral/variant.json
@@ -3,5 +3,8 @@
   "name": "Coral",
   "color_hex": [
     "#C02A29"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/creamstone/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/creamstone/variant.json
@@ -3,5 +3,8 @@
   "name": "Creamstone",
   "color_hex": [
     "#D2CAAE"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/lime/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/lime/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "lime",
   "name": "Lime",
-  "color_hex": "#8CB712"
+  "color_hex": "#8CB712",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/mint/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/mint/variant.json
@@ -3,5 +3,8 @@
   "name": "Mint",
   "color_hex": [
     "#B0C0C4"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/mist_grey/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/mist_grey/variant.json
@@ -3,5 +3,8 @@
   "name": "Mist Grey",
   "color_hex": [
     "#8C9798"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/off_white/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/off_white/variant.json
@@ -3,5 +3,8 @@
   "name": "Off-White",
   "color_hex": [
     "#CFC6BB"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/rosy/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/rosy/variant.json
@@ -3,5 +3,8 @@
   "name": "Rosy",
   "color_hex": [
     "#D9BEC0"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/sage/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/sage/variant.json
@@ -3,5 +3,8 @@
   "name": "Sage",
   "color_hex": [
     "#A1A397"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/pla_matte_hs/white/variant.json
+++ b/data/azurefilm/PLA/pla_matte_hs/white/variant.json
@@ -3,5 +3,8 @@
   "name": "White",
   "color_hex": [
     "#ffffff"
-  ]
+  ],
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/akvamarin/variant.json
+++ b/data/azurefilm/PLA/silk_pla/akvamarin/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "akvamarin",
-    "name": "Akvamarin",
-    "color_hex": "#c5eece",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "akvamarin",
+  "name": "Akvamarin",
+  "color_hex": "#c5eece",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/dark_copper/variant.json
+++ b/data/azurefilm/PLA/silk_pla/dark_copper/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "dark_copper",
-    "name": "Dark copper",
-    "color_hex": "#90535a",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "dark_copper",
+  "name": "Dark copper",
+  "color_hex": "#90535a",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/flame_orange/variant.json
+++ b/data/azurefilm/PLA/silk_pla/flame_orange/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "flame_orange",
-    "name": "Flame orange",
-    "color_hex": "#f3c053",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "flame_orange",
+  "name": "Flame orange",
+  "color_hex": "#f3c053",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/gold/variant.json
+++ b/data/azurefilm/PLA/silk_pla/gold/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "gold",
-    "name": "Gold",
-    "color_hex": "#fbe422",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "gold",
+  "name": "Gold",
+  "color_hex": "#fbe422",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/jungle_gold/variant.json
+++ b/data/azurefilm/PLA/silk_pla/jungle_gold/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "jungle_gold",
-    "name": "Jungle gold",
-    "color_hex": "#b4c500",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "jungle_gold",
+  "name": "Jungle gold",
+  "color_hex": "#b4c500",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/lime/variant.json
+++ b/data/azurefilm/PLA/silk_pla/lime/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "lime",
-    "name": "Lime",
-    "color_hex": "#cef157",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "lime",
+  "name": "Lime",
+  "color_hex": "#cef157",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/ocean_blue/variant.json
+++ b/data/azurefilm/PLA/silk_pla/ocean_blue/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "ocean_blue",
-    "name": "Ocean blue",
-    "color_hex": "#5b95e6",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "ocean_blue",
+  "name": "Ocean blue",
+  "color_hex": "#5b95e6",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/olive_gold/variant.json
+++ b/data/azurefilm/PLA/silk_pla/olive_gold/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "olive_gold",
-    "name": "Olive gold",
-    "color_hex": "#fff480",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "olive_gold",
+  "name": "Olive gold",
+  "color_hex": "#fff480",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/pink/variant.json
+++ b/data/azurefilm/PLA/silk_pla/pink/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "pink",
-    "name": "Pink",
-    "color_hex": "#f088e5",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "pink",
+  "name": "Pink",
+  "color_hex": "#f088e5",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/rainbow_tropicana/variant.json
+++ b/data/azurefilm/PLA/silk_pla/rainbow_tropicana/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "rainbow_tropicana",
   "name": "Rainbow Tropicana",
-  "color_hex": "#D0A6A9"
+  "color_hex": "#D0A6A9",
+  "traits": {
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/rose/variant.json
+++ b/data/azurefilm/PLA/silk_pla/rose/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "rose",
-    "name": "Rose",
-    "color_hex": "#d72830",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "rose",
+  "name": "Rose",
+  "color_hex": "#d72830",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/sand/variant.json
+++ b/data/azurefilm/PLA/silk_pla/sand/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "sand",
-    "name": "Sand",
-    "color_hex": "#d0a85e",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "sand",
+  "name": "Sand",
+  "color_hex": "#d0a85e",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/silver/variant.json
+++ b/data/azurefilm/PLA/silk_pla/silver/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "silver",
-    "name": "Silver",
-    "color_hex": "#d6d6d6",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "silver",
+  "name": "Silver",
+  "color_hex": "#d6d6d6",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/sky_blue/variant.json
+++ b/data/azurefilm/PLA/silk_pla/sky_blue/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "sky_blue",
-    "name": "Sky blue",
-    "color_hex": "#5acdec",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "sky_blue",
+  "name": "Sky blue",
+  "color_hex": "#5acdec",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/turquoise_blue/variant.json
+++ b/data/azurefilm/PLA/silk_pla/turquoise_blue/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "turquoise_blue",
-    "name": "Turquoise blue",
-    "color_hex": "#d3fdf2",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "turquoise_blue",
+  "name": "Turquoise blue",
+  "color_hex": "#d3fdf2",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/silk_pla/white/variant.json
+++ b/data/azurefilm/PLA/silk_pla/white/variant.json
@@ -1,8 +1,9 @@
 {
-    "id": "white",
-    "name": "White",
-    "color_hex": "#e4e8e7",
-    "traits": {
-        "recyclable": true
-    }
+  "id": "white",
+  "name": "White",
+  "color_hex": "#e4e8e7",
+  "traits": {
+    "recyclable": true,
+    "silk": true
+  }
 }

--- a/data/azurefilm/PLA/wood_pla/bamboo/variant.json
+++ b/data/azurefilm/PLA/wood_pla/bamboo/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "bamboo",
-    "name": "Bamboo",
-    "color_hex": "#b59073"
+  "id": "bamboo",
+  "name": "Bamboo",
+  "color_hex": "#b59073",
+  "traits": {
+    "contains_wood": true
+  }
 }

--- a/data/azurefilm/PLA/wood_pla/cork/variant.json
+++ b/data/azurefilm/PLA/wood_pla/cork/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "cork",
-    "name": "Cork",
-    "color_hex": "#6a4f3e"
+  "id": "cork",
+  "name": "Cork",
+  "color_hex": "#6a4f3e",
+  "traits": {
+    "contains_wood": true
+  }
 }

--- a/data/azurefilm/PLA/wood_pla/cork_glitter/variant.json
+++ b/data/azurefilm/PLA/wood_pla/cork_glitter/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "cork_glitter",
-    "name": "Cork glitter",
-    "color_hex": "#8e7d61"
+  "id": "cork_glitter",
+  "name": "Cork glitter",
+  "color_hex": "#8e7d61",
+  "traits": {
+    "contains_wood": true,
+    "glitter": true
+  }
 }

--- a/data/azurefilm/PLA/wood_pla/pine/variant.json
+++ b/data/azurefilm/PLA/wood_pla/pine/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "pine",
-    "name": "Pine",
-    "color_hex": "#c2a085"
+  "id": "pine",
+  "name": "Pine",
+  "color_hex": "#c2a085",
+  "traits": {
+    "contains_wood": true
+  }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 49 AzureFilm filament variant(s).

Add missing `abrasive`, `matte`, `silk`, `glitter`, and `contains_wood` traits to applicable variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
