### PR TITLE
fix: add missing traits to Geeetech filament variants

### DIFF
--- a/data/geeetech/PLA/marble_pla/grey/variant.json
+++ b/data/geeetech/PLA/marble_pla/grey/variant.json
@@ -3,6 +3,7 @@
   "name": "Grey",
   "color_hex": "#B0B0B0",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/geeetech/PLA/marble_pla/marble_white_blue_stone/variant.json
+++ b/data/geeetech/PLA/marble_pla/marble_white_blue_stone/variant.json
@@ -3,7 +3,8 @@
   "name": "Marble White-Blue Stone",
   "color_hex": "#C3CCD5",
   "traits": {
-    "industrially_compostable": true,
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true,
+    "industrially_compostable": true
   }
 }

--- a/data/geeetech/PLA/marble_pla/marble_white_brown_stone/variant.json
+++ b/data/geeetech/PLA/marble_pla/marble_white_brown_stone/variant.json
@@ -3,7 +3,8 @@
   "name": "Marble White-Brown Stone",
   "color_hex": "#EFE8D8",
   "traits": {
-    "industrially_compostable": true,
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true,
+    "industrially_compostable": true
   }
 }

--- a/data/geeetech/PLA/pla/clear/variant.json
+++ b/data/geeetech/PLA/pla/clear/variant.json
@@ -4,6 +4,7 @@
   "color_hex": "#E4E7E5",
   "traits": {
     "industrially_compostable": true,
+    "translucent": true,
     "transparent": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_black_red/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_black_red/variant.json
@@ -6,8 +6,9 @@
     "#AB2614"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_blue_green/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_blue_green/variant.json
@@ -6,8 +6,9 @@
     "#089A45"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_gold_black/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_gold_black/variant.json
@@ -6,8 +6,9 @@
     "#000000"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_gold_copper/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_gold_copper/variant.json
@@ -6,8 +6,9 @@
     "#B87333"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_gold_purple/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_gold_purple/variant.json
@@ -6,8 +6,9 @@
     "#800080"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_gold_red/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_gold_red/variant.json
@@ -6,8 +6,9 @@
     "#CC0000"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_gold_silver/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_gold_silver/variant.json
@@ -6,8 +6,9 @@
     "#C0C0C0"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/dual_color_green_red/variant.json
+++ b/data/geeetech/PLA/silk_pla/dual_color_green_red/variant.json
@@ -6,8 +6,9 @@
     "#861D2B"
   ],
   "traits": {
+    "coextruded": true,
     "industrially_compostable": true,
-    "silk": true,
-    "coextruded": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/PLA/silk_pla/rainbow/variant.json
+++ b/data/geeetech/PLA/silk_pla/rainbow/variant.json
@@ -9,8 +9,9 @@
     "#0099E6"
   ],
   "traits": {
+    "gradual_color_change": true,
     "industrially_compostable": true,
-    "silk": true,
-    "gradual_color_change": true
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/geeetech/TPU/tpu/95a_clear_gold/variant.json
+++ b/data/geeetech/TPU/tpu/95a_clear_gold/variant.json
@@ -1,5 +1,8 @@
 {
   "id": "95a_clear_gold",
   "name": "95A Clear Gold",
-  "color_hex": "#CE8D00"
+  "color_hex": "#CE8D00",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/geeetech/TPU/tpu/95a_transparent/variant.json
+++ b/data/geeetech/TPU/tpu/95a_transparent/variant.json
@@ -3,6 +3,7 @@
   "name": "95A Transparent",
   "color_hex": "#E4E7E5",
   "traits": {
+    "translucent": true,
     "transparent": true
   }
 }

--- a/data/geeetech/TPU/tpu/clear/variant.json
+++ b/data/geeetech/TPU/tpu/clear/variant.json
@@ -3,6 +3,7 @@
   "name": "Clear",
   "color_hex": "#E4E7E5",
   "traits": {
+    "translucent": true,
     "transparent": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 16 Geeetech filament variant(s).

Add missing `imitates_stone`, `iridescent`, and `translucent` traits to marble, silk dual-color, and clear variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
