### PR TITLE
fix: add missing matte trait to IEMAI CF PC variant

### DIFF
--- a/data/iemai/PC/cf_pc/matte_black/variant.json
+++ b/data/iemai/PC/cf_pc/matte_black/variant.json
@@ -4,6 +4,7 @@
   "color_hex": "#1A1A1A",
   "traits": {
     "abrasive": true,
-    "contains_carbon_fiber": true
+    "contains_carbon_fiber": true,
+    "matte": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing `matte` trait to IEMAI CF PC (Carbon Fiber Polycarbonate) Matte Black variant.

## Changes

- Updated `data/iemai/PC/cf_pc/matte_black/variant.json` to add `matte: true` trait
- The variant already had `abrasive` and `contains_carbon_fiber` traits; this adds the missing `matte` trait matching the product's matte finish
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
