### PR TITLE
fix: add missing traits to Inslogic filament variants

### DIFF
--- a/data/inslogic/ABS/abs_gf10/natural/variant.json
+++ b/data/inslogic/ABS/abs_gf10/natural/variant.json
@@ -3,6 +3,7 @@
   "name": "Natural",
   "color_hex": "#F5F5DC",
   "traits": {
+    "abrasive": true,
     "contains_glass_fiber": true
   }
 }

--- a/data/inslogic/PA12/pa12_cf/black/variant.json
+++ b/data/inslogic/PA12/pa12_cf/black/variant.json
@@ -3,6 +3,7 @@
   "name": "Black",
   "color_hex": "#1A1A1A",
   "traits": {
+    "abrasive": true,
     "contains_carbon_fiber": true
   }
 }

--- a/data/inslogic/PA6/pa6_cf/black/variant.json
+++ b/data/inslogic/PA6/pa6_cf/black/variant.json
@@ -3,6 +3,7 @@
   "name": "Black",
   "color_hex": "#1A1A1A",
   "traits": {
+    "abrasive": true,
     "contains_carbon_fiber": true
   }
 }

--- a/data/inslogic/PA6/pa6_gf25/natural/variant.json
+++ b/data/inslogic/PA6/pa6_gf25/natural/variant.json
@@ -3,6 +3,7 @@
   "name": "Natural",
   "color_hex": "#F5F5DC",
   "traits": {
+    "abrasive": true,
     "contains_glass_fiber": true
   }
 }

--- a/data/inslogic/PETG/petg_cf10/black/variant.json
+++ b/data/inslogic/PETG/petg_cf10/black/variant.json
@@ -3,6 +3,7 @@
   "name": "Black",
   "color_hex": "#1A1A1A",
   "traits": {
+    "abrasive": true,
     "contains_carbon_fiber": true
   }
 }

--- a/data/inslogic/PLA/high_speed_marble_pla/brick/variant.json
+++ b/data/inslogic/PLA/high_speed_marble_pla/brick/variant.json
@@ -3,6 +3,7 @@
   "name": "Brick",
   "color_hex": "#A0522D",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/inslogic/PLA/high_speed_marble_pla/grey/variant.json
+++ b/data/inslogic/PLA/high_speed_marble_pla/grey/variant.json
@@ -3,6 +3,7 @@
   "name": "Grey",
   "color_hex": "#808080",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/inslogic/PLA/high_speed_marble_pla/white/variant.json
+++ b/data/inslogic/PLA/high_speed_marble_pla/white/variant.json
@@ -3,6 +3,7 @@
   "name": "White",
   "color_hex": "#FFFFFF",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/inslogic/PLA/multicolor_silk_pla/rainbow/variant.json
+++ b/data/inslogic/PLA/multicolor_silk_pla/rainbow/variant.json
@@ -3,7 +3,8 @@
   "name": "Rainbow",
   "color_hex": "#FF0000",
   "traits": {
-    "silk": true,
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/inslogic/PLA/pla_cf15/black/variant.json
+++ b/data/inslogic/PLA/pla_cf15/black/variant.json
@@ -3,6 +3,7 @@
   "name": "Black",
   "color_hex": "#1A1A1A",
   "traits": {
+    "abrasive": true,
     "contains_carbon_fiber": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 10 Inslogic filament variant(s).

Add missing `abrasive`, `imitates_stone`, and `iridescent` traits to applicable variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
