### PR TITLE
fix: add missing traits to QIDI Tech filament variants

### DIFF
--- a/data/qidi_tech/ABS/gf25/black/variant.json
+++ b/data/qidi_tech/ABS/gf25/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/ABS/gf25/green/variant.json
+++ b/data/qidi_tech/ABS/gf25/green/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "green",
-    "name": "Green",
-    "color_hex": "#00A247"
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#00A247",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/ABS/gf25/purple/variant.json
+++ b/data/qidi_tech/ABS/gf25/purple/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "purple",
-    "name": "Purple",
-    "color_hex": "#7F347C"
+  "id": "purple",
+  "name": "Purple",
+  "color_hex": "#7F347C",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/ABS/gf25/red/variant.json
+++ b/data/qidi_tech/ABS/gf25/red/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "red",
-    "name": "Red",
-    "color_hex": "#C03023"
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#C03023",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PA12/cf/black/variant.json
+++ b/data/qidi_tech/PA12/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PET/cf/black/variant.json
+++ b/data/qidi_tech/PET/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PET/gf/black/variant.json
+++ b/data/qidi_tech/PET/gf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#212322"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#212322",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PET/gf/brown/variant.json
+++ b/data/qidi_tech/PET/gf/brown/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "brown",
-    "name": "Brown",
-    "color_hex": "#946037"
+  "id": "brown",
+  "name": "Brown",
+  "color_hex": "#946037",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PET/gf/red/variant.json
+++ b/data/qidi_tech/PET/gf/red/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "red",
-    "name": "Red",
-    "color_hex": "#CD001A"
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#CD001A",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PETG/cf/black/variant.json
+++ b/data/qidi_tech/PETG/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PETG/gf/black/variant.json
+++ b/data/qidi_tech/PETG/gf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PETG/gf/macchiato_brown/variant.json
+++ b/data/qidi_tech/PETG/gf/macchiato_brown/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "macchiato_brown",
-    "name": "Macchiato Brown",
-    "color_hex": "#AC8266"
+  "id": "macchiato_brown",
+  "name": "Macchiato Brown",
+  "color_hex": "#AC8266",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PETG/gf/skylight_blue/variant.json
+++ b/data/qidi_tech/PETG/gf/skylight_blue/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "skylight_blue",
-    "name": "Skylight Blue",
-    "color_hex": "#C8E0E0"
+  "id": "skylight_blue",
+  "name": "Skylight Blue",
+  "color_hex": "#C8E0E0",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PETG/gf/white/variant.json
+++ b/data/qidi_tech/PETG/gf/white/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "white",
-    "name": "White",
-    "color_hex": "#FFFFFF"
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PETG/rapido/diffuse_clear_white/variant.json
+++ b/data/qidi_tech/PETG/rapido/diffuse_clear_white/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "diffuse_clear_white",
-    "name": "Diffuse Clear White",
-    "color_hex": "#FFFFFF"
+  "id": "diffuse_clear_white",
+  "name": "Diffuse Clear White",
+  "color_hex": "#FFFFFF",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PETG/translucent/black/variant.json
+++ b/data/qidi_tech/PETG/translucent/black/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#333333"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#333333",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PETG/translucent/blue/variant.json
+++ b/data/qidi_tech/PETG/translucent/blue/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "blue",
-    "name": "Blue",
-    "color_hex": "#3399FF"
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#3399FF",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PETG/translucent/clear/variant.json
+++ b/data/qidi_tech/PETG/translucent/clear/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "clear",
-    "name": "Clear",
-    "color_hex": "#E0E0E0"
+  "id": "clear",
+  "name": "Clear",
+  "color_hex": "#E0E0E0",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PETG/translucent/purple/variant.json
+++ b/data/qidi_tech/PETG/translucent/purple/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "purple",
-    "name": "Purple",
-    "color_hex": "#9933FF"
+  "id": "purple",
+  "name": "Purple",
+  "color_hex": "#9933FF",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PETG/translucent/red/variant.json
+++ b/data/qidi_tech/PETG/translucent/red/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "red",
-    "name": "Red",
-    "color_hex": "#FF4D4D"
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#FF4D4D",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PETG/translucent/yellow/variant.json
+++ b/data/qidi_tech/PETG/translucent/yellow/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "yellow",
-    "name": "Yellow",
-    "color_hex": "#FFFF33"
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#FFFF33",
+  "traits": {
+    "translucent": true
+  }
 }

--- a/data/qidi_tech/PLA/cf/black/variant.json
+++ b/data/qidi_tech/PLA/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PLA/cf/dark_red/variant.json
+++ b/data/qidi_tech/PLA/cf/dark_red/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "dark_red",
-    "name": "Dark Red",
-    "color_hex": "#9A5C6B"
+  "id": "dark_red",
+  "name": "Dark Red",
+  "color_hex": "#9A5C6B",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PLA/cf/lavender_purple/variant.json
+++ b/data/qidi_tech/PLA/cf/lavender_purple/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "lavender_purple",
-    "name": "Lavender Purple",
-    "color_hex": "#660066"
+  "id": "lavender_purple",
+  "name": "Lavender Purple",
+  "color_hex": "#660066",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PLA/cf/midnight_blue/variant.json
+++ b/data/qidi_tech/PLA/cf/midnight_blue/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "midnight_blue",
-    "name": "Midnight Blue",
-    "color_hex": "#566B8F"
+  "id": "midnight_blue",
+  "name": "Midnight Blue",
+  "color_hex": "#566B8F",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PLA/cf/olive_green/variant.json
+++ b/data/qidi_tech/PLA/cf/olive_green/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "olive_green",
-    "name": "Olive Green",
-    "color_hex": "#67785A"
+  "id": "olive_green",
+  "name": "Olive Green",
+  "color_hex": "#67785A",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/coconut_white/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/coconut_white/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "coconut_white",
-    "name": "Coconut White",
-    "color_hex": "#FFFFFF"
+  "id": "coconut_white",
+  "name": "Coconut White",
+  "color_hex": "#FFFFFF",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/latte_brown/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/latte_brown/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "latte_brown",
-    "name": "Latte Brown",
-    "color_hex": "#8C6952"
+  "id": "latte_brown",
+  "name": "Latte Brown",
+  "color_hex": "#8C6952",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/malt_green/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/malt_green/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "malt_green",
-    "name": "Malt Green",
-    "color_hex": "#9AD24B"
+  "id": "malt_green",
+  "name": "Malt Green",
+  "color_hex": "#9AD24B",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/milky_green/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/milky_green/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "milky_green",
-    "name": "Milky Green",
-    "color_hex": "#D8E9DB"
+  "id": "milky_green",
+  "name": "Milky Green",
+  "color_hex": "#D8E9DB",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/mint_blue/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/mint_blue/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "mint_blue",
-    "name": "Mint Blue",
-    "color_hex": "#9CD4EB"
+  "id": "mint_blue",
+  "name": "Mint Blue",
+  "color_hex": "#9CD4EB",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/peach_pink/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/peach_pink/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "peach_pink",
-    "name": "Peach Pink",
-    "color_hex": "#F5D3D6"
+  "id": "peach_pink",
+  "name": "Peach Pink",
+  "color_hex": "#F5D3D6",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/sesame_black/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/sesame_black/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "sesame_black",
-    "name": "Sesame Black",
-    "color_hex": "#000000"
+  "id": "sesame_black",
+  "name": "Sesame Black",
+  "color_hex": "#000000",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_basic/watermelon_red/variant.json
+++ b/data/qidi_tech/PLA/matte_basic/watermelon_red/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "watermelon_red",
-    "name": "Watermelon Red",
-    "color_hex": "#F45D6D"
+  "id": "watermelon_red",
+  "name": "Watermelon Red",
+  "color_hex": "#F45D6D",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/ash_gray/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/ash_gray/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "ash_gray",
-    "name": "Ash Gray",
-    "color_hex": "#313335"
+  "id": "ash_gray",
+  "name": "Ash Gray",
+  "color_hex": "#313335",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/black/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/black/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#212322"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#212322",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/kraft/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/kraft/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "kraft",
-    "name": "Kraft",
-    "color_hex": "#C6AA76"
+  "id": "kraft",
+  "name": "Kraft",
+  "color_hex": "#C6AA76",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/malt_clay/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/malt_clay/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "malt_clay",
-    "name": "Malt Clay",
-    "color_hex": "#876E59"
+  "id": "malt_clay",
+  "name": "Malt Clay",
+  "color_hex": "#876E59",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/navy_blue/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/navy_blue/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "navy_blue",
-    "name": "Navy Blue",
-    "color_hex": "#353E47"
+  "id": "navy_blue",
+  "name": "Navy Blue",
+  "color_hex": "#353E47",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/olive_green/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/olive_green/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "olive_green",
-    "name": "Olive Green",
-    "color_hex": "#555B43"
+  "id": "olive_green",
+  "name": "Olive Green",
+  "color_hex": "#555B43",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/tech_gray/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/tech_gray/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "tech_gray",
-    "name": "Tech Gray",
-    "color_hex": "#C1C1C1"
+  "id": "tech_gray",
+  "name": "Tech Gray",
+  "color_hex": "#C1C1C1",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/warm_gray/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/warm_gray/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "warm_gray",
-    "name": "Warm Gray",
-    "color_hex": "#B7ADA5"
+  "id": "warm_gray",
+  "name": "Warm Gray",
+  "color_hex": "#B7ADA5",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/matte_rapido/white/variant.json
+++ b/data/qidi_tech/PLA/matte_rapido/white/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "white",
-    "name": "White",
-    "color_hex": "#FFFFFF"
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF",
+  "traits": {
+    "matte": true
+  }
 }

--- a/data/qidi_tech/PLA/silk_rapido/bronze/variant.json
+++ b/data/qidi_tech/PLA/silk_rapido/bronze/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "bronze",
-    "name": "Bronze",
-    "color_hex": "#BEB09E"
+  "id": "bronze",
+  "name": "Bronze",
+  "color_hex": "#BEB09E",
+  "traits": {
+    "silk": true
+  }
 }

--- a/data/qidi_tech/PLA/silk_rapido/green/variant.json
+++ b/data/qidi_tech/PLA/silk_rapido/green/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "green",
-    "name": "Green",
-    "color_hex": "#BDF2E0"
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#BDF2E0",
+  "traits": {
+    "silk": true
+  }
 }

--- a/data/qidi_tech/PLA/silk_rapido/rose_red/variant.json
+++ b/data/qidi_tech/PLA/silk_rapido/rose_red/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "rose_red",
-    "name": "Rose Red",
-    "color_hex": "#D6A2A1"
+  "id": "rose_red",
+  "name": "Rose Red",
+  "color_hex": "#D6A2A1",
+  "traits": {
+    "silk": true
+  }
 }

--- a/data/qidi_tech/PLA/silk_rapido/skin/variant.json
+++ b/data/qidi_tech/PLA/silk_rapido/skin/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "skin",
-    "name": "Skin",
-    "color_hex": "#F2DCC2"
+  "id": "skin",
+  "name": "Skin",
+  "color_hex": "#F2DCC2",
+  "traits": {
+    "silk": true
+  }
 }

--- a/data/qidi_tech/PLA/wood/cedar_brown/variant.json
+++ b/data/qidi_tech/PLA/wood/cedar_brown/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "cedar_brown",
-    "name": "Cedar Brown",
-    "color_hex": "#A67F6B"
+  "id": "cedar_brown",
+  "name": "Cedar Brown",
+  "color_hex": "#A67F6B",
+  "traits": {
+    "contains_wood": true
+  }
 }

--- a/data/qidi_tech/PLA/wood/yellow/variant.json
+++ b/data/qidi_tech/PLA/wood/yellow/variant.json
@@ -1,5 +1,8 @@
 {
-    "id": "yellow",
-    "name": "Yellow",
-    "color_hex": "#B7916C"
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#B7916C",
+  "traits": {
+    "contains_wood": true
+  }
 }

--- a/data/qidi_tech/PPA/cf/black/variant.json
+++ b/data/qidi_tech/PPA/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PPA/cf25/black/variant.json
+++ b/data/qidi_tech/PPA/cf25/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PPA/gf/blue/variant.json
+++ b/data/qidi_tech/PPA/gf/blue/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "blue",
-    "name": "Blue",
-    "color_hex": "#7CA6DE"
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#7CA6DE",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PPA/gf/gray/variant.json
+++ b/data/qidi_tech/PPA/gf/gray/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "gray",
-    "name": "Gray",
-    "color_hex": "#A2AAAD"
+  "id": "gray",
+  "name": "Gray",
+  "color_hex": "#A2AAAD",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }

--- a/data/qidi_tech/PPS/cf/black/variant.json
+++ b/data/qidi_tech/PPS/cf/black/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "black",
-    "name": "Black",
-    "color_hex": "#000000"
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
 }

--- a/data/qidi_tech/PPS/gf20/gray/variant.json
+++ b/data/qidi_tech/PPS/gf20/gray/variant.json
@@ -1,5 +1,9 @@
 {
-    "id": "gray",
-    "name": "Gray",
-    "color_hex": "#75787B"
+  "id": "gray",
+  "name": "Gray",
+  "color_hex": "#75787B",
+  "traits": {
+    "abrasive": true,
+    "contains_glass_fiber": true
+  }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 55 QIDI Tech filament variant(s).

Add missing `abrasive`, `matte`, `silk`, `contains_wood`, and `translucent` traits to applicable variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
