### PR TITLE
fix: add missing traits to TEQStone filament variants

### DIFF
--- a/data/teqstone/PLA/marble_pla/blue/variant.json
+++ b/data/teqstone/PLA/marble_pla/blue/variant.json
@@ -3,6 +3,7 @@
   "name": "Blue",
   "color_hex": "#6495ED",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/teqstone/PLA/marble_pla/brown/variant.json
+++ b/data/teqstone/PLA/marble_pla/brown/variant.json
@@ -3,6 +3,7 @@
   "name": "Brown",
   "color_hex": "#D2B48C",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/teqstone/PLA/marble_pla/grey/variant.json
+++ b/data/teqstone/PLA/marble_pla/grey/variant.json
@@ -3,6 +3,7 @@
   "name": "Grey",
   "color_hex": "#B0B0B0",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/teqstone/PLA/pla_cf/black/variant.json
+++ b/data/teqstone/PLA/pla_cf/black/variant.json
@@ -3,6 +3,7 @@
   "name": "Black",
   "color_hex": "#1A1A1A",
   "traits": {
+    "abrasive": true,
     "contains_carbon_fiber": true
   }
 }

--- a/data/teqstone/PLA/silk_pla/rainbow/variant.json
+++ b/data/teqstone/PLA/silk_pla/rainbow/variant.json
@@ -3,7 +3,8 @@
   "name": "Rainbow",
   "color_hex": "#FF0000",
   "traits": {
-    "silk": true,
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true,
+    "silk": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 5 TEQStone filament variant(s).

Add missing `abrasive`, `imitates_stone`, and `iridescent` traits to applicable variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
