### PR TITLE
fix: add missing traits to XZN filament variants

### DIFF
--- a/data/xzn/PETG/petg/transparent/variant.json
+++ b/data/xzn/PETG/petg/transparent/variant.json
@@ -3,6 +3,7 @@
   "name": "Transparent",
   "color_hex": "#F5F5F5",
   "traits": {
+    "translucent": true,
     "transparent": true
   }
 }

--- a/data/xzn/PLA/gradient_pla/rainbow/variant.json
+++ b/data/xzn/PLA/gradient_pla/rainbow/variant.json
@@ -3,6 +3,7 @@
   "name": "Rainbow",
   "color_hex": "#FF0000",
   "traits": {
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true
   }
 }

--- a/data/xzn/PLA/marble_pla/grey/variant.json
+++ b/data/xzn/PLA/marble_pla/grey/variant.json
@@ -3,6 +3,7 @@
   "name": "Grey",
   "color_hex": "#B0B0B0",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/xzn/PLA/marble_pla/white/variant.json
+++ b/data/xzn/PLA/marble_pla/white/variant.json
@@ -3,6 +3,7 @@
   "name": "White",
   "color_hex": "#FFFFFF",
   "traits": {
-    "imitates_marble": true
+    "imitates_marble": true,
+    "imitates_stone": true
   }
 }

--- a/data/xzn/PLA/silk_pla/rainbow/variant.json
+++ b/data/xzn/PLA/silk_pla/rainbow/variant.json
@@ -3,7 +3,8 @@
   "name": "Rainbow",
   "color_hex": "#FF0000",
   "traits": {
-    "silk": true,
-    "gradual_color_change": true
+    "gradual_color_change": true,
+    "iridescent": true,
+    "silk": true
   }
 }

--- a/data/xzn/PLA/transparent_pla/clear/variant.json
+++ b/data/xzn/PLA/transparent_pla/clear/variant.json
@@ -3,6 +3,7 @@
   "name": "Clear",
   "color_hex": "#F4FAFC",
   "traits": {
+    "translucent": true,
     "transparent": true
   }
 }

--- a/data/xzn/TPU/tpu_95a/transparent/variant.json
+++ b/data/xzn/TPU/tpu_95a/transparent/variant.json
@@ -3,6 +3,7 @@
   "name": "Transparent",
   "color_hex": "#F5F5F5",
   "traits": {
+    "translucent": true,
     "transparent": true
   }
 }


### PR DESCRIPTION
## Summary

Add missing traits to 7 XZN filament variant(s).

Add missing `imitates_stone`, `iridescent`, and `translucent` traits to applicable variants.

## Changes

- Updated `variant.json` files with correct trait properties based on product descriptions
- All traits validated against vendor product pages and filament specifications
- Traits follow the schema definitions in `schemas/variant_schema.json`

## Validation

- ✅ `./ofd.sh validate` passes with all changes
