### PR TITLE
add missing PrimaValue PLA+ filament (matte black)

### DIFF
--- a/data/primavalue/PLA/pla+/filament.json
+++ b/data/primavalue/PLA/pla+/filament.json
@@ -1,0 +1,19 @@
+{
+  "id": "pla+",
+  "name": "PLA+",
+  "diameter_tolerance": 0.02,
+  "density": 1.24,
+  "min_print_temperature": 200,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 75,
+  "max_bed_temperature": 90,
+  "data_sheet_url": "https://primacreator.com/products/primavalue-pla?variant=48794154467675",
+  "slicer_settings": {
+    "generic": {
+      "first_layer_bed_temp": 80,
+      "first_layer_nozzle_temp": 225,
+      "bed_temp": 75,
+      "nozzle_temp": 215
+    }
+  }
+}

--- a/data/primavalue/PLA/pla+/matte_black/sizes.json
+++ b/data/primavalue/PLA/pla+/matte_black/sizes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75
+  }
+]

--- a/data/primavalue/PLA/pla+/matte_black/variant.json
+++ b/data/primavalue/PLA/pla+/matte_black/variant.json
@@ -1,0 +1,8 @@
+{
+  "id": "matte_black",
+  "name": "Matte Black",
+  "color_hex": "#1A1A1A",
+  "traits": {
+    "industrially_compostable": true
+  }
+}

--- a/data/primavalue/PLA/pla+/matte_black/variant.json
+++ b/data/primavalue/PLA/pla+/matte_black/variant.json
@@ -3,6 +3,7 @@
   "name": "Matte Black",
   "color_hex": "#1A1A1A",
   "traits": {
-    "industrially_compostable": true
+    "industrially_compostable": true,
+    "matte": true
   }
 }


### PR DESCRIPTION
Values taken from [PrimaCreator](https://primacreator.com/products/primavalue-pla?variant=48794154467675) technical data, adjusted first layer bed temps accordingly.

According to their page, PLA+ should be stronger than standard PLA and more eco-friendly. Settings here are ones I use in my Prusa Core One+
