### PR TITLE
Added Bambu PETG Classic new colors

### DIFF
--- a/data/bambu_lab/PETG/petg_basic/black/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/black/sizes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 250,
+    "spool_core_diameter": 100,
+    "discontinued": false
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/black/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/black/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false
+}

--- a/data/bambu_lab/PETG/petg_basic/dark_brown/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/dark_brown/sizes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 250,
+    "spool_core_diameter": 100,
+    "discontinued": false
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/dark_brown/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/dark_brown/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "dark_brown",
+  "name": "Dark Brown",
+  "color_hex": "#502C1E",
+  "discontinued": false
+}

--- a/data/bambu_lab/PETG/petg_basic/filament.json
+++ b/data/bambu_lab/PETG/petg_basic/filament.json
@@ -1,0 +1,24 @@
+{
+  "id": "petg_basic",
+  "name": "PETG Basic",
+  "diameter_tolerance": 0.03,
+  "density": 1.25,
+  "discontinued": false,
+  "slicer_settings": {
+    "bambustudio": {
+      "generic_id": "GFG99",
+      "id": "GFG00",
+      "profile_name": "Bambu PETG Basic"
+    },
+    "orcaslicer": {
+      "generic_id": "GFG99",
+      "id": "GFG00",
+      "profile_name": "Bambu PETG Basic"
+    },
+    "elegooslicer": {
+      "generic_id": "GFG99",
+      "id": "OGFG00",
+      "profile_name": "Bambu PETG Basic"
+    }
+  }
+}

--- a/data/bambu_lab/PETG/petg_basic/gray/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/gray/sizes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 250,
+    "spool_core_diameter": 100,
+    "discontinued": false
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/gray/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/gray/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "gray",
+  "name": "Gray",
+  "color_hex": "#7F7E83",
+  "discontinued": false
+}

--- a/data/bambu_lab/PETG/petg_basic/lime_green/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/lime_green/sizes.json
@@ -1,13 +1,13 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.25,
+    "diameter": 1.75,
     "spool_refill": false,
     "gtin": "6975337032847",
     "discontinued": false,
     "purchase_links": [
       {
-        "store_id": "f78b7ee7-b60e-573d-a98e-f1531ca751b2",
+        "store_id": "3deksperten",
         "url": "https://3deksperten.dk/products/bambu-lab-petg-basic-lime-green-1-75mm-1kg"
       }
     ]

--- a/data/bambu_lab/PETG/petg_basic/lime_green/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/lime_green/sizes.json
@@ -1,0 +1,15 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.25,
+    "spool_refill": false,
+    "gtin": "6975337032847",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "f78b7ee7-b60e-573d-a98e-f1531ca751b2",
+        "url": "https://3deksperten.dk/products/bambu-lab-petg-basic-lime-green-1-75mm-1kg"
+      }
+    ]
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/lime_green/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/lime_green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "lime_green",
+  "name": "Lime Green",
+  "color_hex": "#62AF41",
+  "discontinued": true
+}

--- a/data/bambu_lab/PETG/petg_basic/purple/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/purple/sizes.json
@@ -7,7 +7,7 @@
     "discontinued": false,
     "purchase_links": [
       {
-        "store_id": "f78b7ee7-b60e-573d-a98e-f1531ca751b2",
+        "store_id": "3deksperten",
         "url": "https://3deksperten.dk/products/bambu-lab-petg-basic-purple-1-75mm-1kg"
       }
     ]

--- a/data/bambu_lab/PETG/petg_basic/purple/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/purple/sizes.json
@@ -1,0 +1,15 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "gtin": "6975337032830",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "f78b7ee7-b60e-573d-a98e-f1531ca751b2",
+        "url": "https://3deksperten.dk/products/bambu-lab-petg-basic-purple-1-75mm-1kg"
+      }
+    ]
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/purple/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/purple/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "purple",
+  "name": "Purple",
+  "color_hex": "#990E95",
+  "discontinued": true
+}

--- a/data/bambu_lab/PETG/petg_basic/reflex_blue/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/reflex_blue/sizes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 250,
+    "spool_core_diameter": 100,
+    "discontinued": false
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/reflex_blue/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/reflex_blue/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "reflex_blue",
+  "name": "Reflex Blue",
+  "color_hex": "#001389",
+  "discontinued": false
+}

--- a/data/bambu_lab/PETG/petg_basic/white/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/white/sizes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 250,
+    "spool_core_diameter": 100,
+    "discontinued": false
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/white/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/white/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF",
+  "discontinued": false
+}

--- a/data/bambu_lab/PETG/petg_basic/yellow/sizes.json
+++ b/data/bambu_lab/PETG/petg_basic/yellow/sizes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 250,
+    "spool_core_diameter": 100,
+    "discontinued": false
+  }
+]

--- a/data/bambu_lab/PETG/petg_basic/yellow/variant.json
+++ b/data/bambu_lab/PETG/petg_basic/yellow/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#FCE300",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "PETG Basic"
- [+] Created variant "Black"
- [~] Updated variant "Lime Green"
- [~] Updated variant "Purple"
- [+] Created variant "White"
- [+] Created variant "Gray"
- [+] Created variant "Dark Brown"
- [+] Created variant "Reflex Blue"
- [+] Created variant "Yellow"

*Submitted by @PatrykWa via the OFD web editor*