### PR TITLE
Updated FormFutura TitanX variants.

### DIFF
--- a/data/formfutura/ABS/titanx_abs/black/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/black/sizes.json
@@ -1,6 +1,100 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175BLCK-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175BLCK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-175BLCK-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "TITX-175BLCK-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285BLCK-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-285BLCK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-285BLCK-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/black/variant.json
+++ b/data/formfutura/ABS/titanx_abs/black/variant.json
@@ -2,6 +2,7 @@
   "id": "black",
   "name": "Black",
   "color_hex": "#000000",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/titanx_abs/dark_blue/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/dark_blue/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175DBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175DBLU-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285DBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/dark_blue/variant.json
+++ b/data/formfutura/ABS/titanx_abs/dark_blue/variant.json
@@ -2,6 +2,7 @@
   "id": "dark_blue",
   "name": "Dark Blue",
   "color_hex": "#0E21AE",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/titanx_abs/filament.json
+++ b/data/formfutura/ABS/titanx_abs/filament.json
@@ -1,10 +1,13 @@
 {
   "id": "titanx_abs",
-  "name": "TitanX ABS",
+  "name": "TitanX",
   "diameter_tolerance": 0.02,
-  "density": 1.04,
-  "min_print_temperature": 230,
-  "max_print_temperature": 260,
-  "min_bed_temperature": 90,
-  "max_bed_temperature": 110
+  "density": 1.05,
+  "min_print_temperature": 245,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 110,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256648?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256647?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/ABS/titanx_abs/grey/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/grey/sizes.json
@@ -1,6 +1,72 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175GREY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175GREY-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-175GREY-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "TITX-175GREY-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285GREY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/grey/variant.json
+++ b/data/formfutura/ABS/titanx_abs/grey/variant.json
@@ -2,6 +2,7 @@
   "id": "grey",
   "name": "Grey",
   "color_hex": "#727376",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/titanx_abs/light_grey/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/light_grey/sizes.json
@@ -1,6 +1,100 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175LGRY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175LGRY-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-175LGRY-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "TITX-175LGRY-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285LGRY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-285LGRY-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-285LGRY-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/light_grey/variant.json
+++ b/data/formfutura/ABS/titanx_abs/light_grey/variant.json
@@ -2,6 +2,7 @@
   "id": "light_grey",
   "name": "Light Grey",
   "color_hex": "#C3CCD5",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/titanx_abs/natural/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/natural/sizes.json
@@ -1,6 +1,86 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175NTRL-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175NTRL-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-175NTRL-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285NTRL-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-285NTRL-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-285NTRL-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/natural/variant.json
+++ b/data/formfutura/ABS/titanx_abs/natural/variant.json
@@ -2,6 +2,7 @@
   "id": "natural",
   "name": "Natural",
   "color_hex": "#DFDFD3",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/titanx_abs/red/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/red/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175REDC-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175REDC-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285REDC-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/red/variant.json
+++ b/data/formfutura/ABS/titanx_abs/red/variant.json
@@ -2,6 +2,7 @@
   "id": "red",
   "name": "Red",
   "color_hex": "#F00C00",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/titanx_abs/white/sizes.json
+++ b/data/formfutura/ABS/titanx_abs/white/sizes.json
@@ -1,6 +1,100 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-175WHTE-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-175WHTE-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-175WHTE-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "TITX-175WHTE-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "TITX-285WHTE-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "TITX-285WHTE-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "TITX-285WHTE-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/titanx"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/titanx_abs/white/variant.json
+++ b/data/formfutura/ABS/titanx_abs/white/variant.json
@@ -2,6 +2,7 @@
   "id": "white",
   "name": "White",
   "color_hex": "#FFFFFF",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "TitanX"
- [~] Updated variant "Black"
- [~] Updated variant "White"
- [~] Updated variant "Grey"
- [~] Updated variant "Light Grey"
- [~] Updated variant "Natural"
- [~] Updated variant "Dark Blue"
- [~] Updated variant "Red"

*Submitted by @Njord-FormFutura via the OFD web editor*