### PR TITLE
Updated FormFutura ABSpro Flame Retardant variants.

### DIFF
--- a/data/formfutura/ABS/flame_retardant_abs/black/sizes.json
+++ b/data/formfutura/ABS/flame_retardant_abs/black/sizes.json
@@ -1,6 +1,58 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "APFR-175BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "APFR-175BLCK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "APFR-175BLCK-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
+  },
+  {
+    "filament_weight": 500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "APFR-285BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/flame_retardant_abs/black/variant.json
+++ b/data/formfutura/ABS/flame_retardant_abs/black/variant.json
@@ -2,6 +2,7 @@
   "id": "black",
   "name": "Black",
   "color_hex": "#000000",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true,
     "self_extinguishing": true

--- a/data/formfutura/ABS/flame_retardant_abs/filament.json
+++ b/data/formfutura/ABS/flame_retardant_abs/filament.json
@@ -1,10 +1,13 @@
 {
   "id": "flame_retardant_abs",
-  "name": "Flame Retardant ABS",
+  "name": "ABSpro Flame Retardant",
   "diameter_tolerance": 0.02,
-  "density": 1.04,
-  "min_print_temperature": 230,
-  "max_print_temperature": 260,
-  "min_bed_temperature": 90,
-  "max_bed_temperature": 110
+  "density": 1.17,
+  "min_print_temperature": 240,
+  "max_print_temperature": 265,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 110,
+  "data_sheet_url": "https://www.formfutura.com/web/content/254655?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/254656?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/ABS/flame_retardant_abs/white/sizes.json
+++ b/data/formfutura/ABS/flame_retardant_abs/white/sizes.json
@@ -1,6 +1,58 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "APFR-175WHTE-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "APFR-175WHTE-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "APFR-175WHTE-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
+  },
+  {
+    "filament_weight": 500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "APFR-285WHTE-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/abspro-flame-retardant"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/flame_retardant_abs/white/variant.json
+++ b/data/formfutura/ABS/flame_retardant_abs/white/variant.json
@@ -2,6 +2,7 @@
   "id": "white",
   "name": "White",
   "color_hex": "#FFFFFF",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true,
     "self_extinguishing": true


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "ABSpro Flame Retardant"
- [~] Updated variant "Black"
- [~] Updated variant "White"

*Submitted by @Njord-FormFutura via the OFD web editor*