### PR TITLE
Updated FormFutura EasyFil ABS variants.

### DIFF
--- a/data/formfutura/ABS/easyfil_abs/black/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/black/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175BLCK-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/black/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/black/variant.json
@@ -2,6 +2,7 @@
   "id": "black",
   "name": "Black",
   "color_hex": "#000000",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/bronze/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/bronze/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175BRNZ-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-285BRNZ-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/bronze/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/bronze/variant.json
@@ -2,6 +2,7 @@
   "id": "bronze",
   "name": "Bronze",
   "color_hex": "#A18D5A",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/brown/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/brown/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175BRWN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/brown/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/brown/variant.json
@@ -2,6 +2,7 @@
   "id": "brown",
   "name": "Brown",
   "color_hex": "#694D3F",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/dark_blue/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/dark_blue/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175DBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-285DBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/dark_blue/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/dark_blue/variant.json
@@ -2,6 +2,7 @@
   "id": "dark_blue",
   "name": "Dark Blue",
   "color_hex": "#0353BA",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/dark_green/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/dark_green/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175DGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-285DGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/dark_green/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/dark_green/variant.json
@@ -2,6 +2,7 @@
   "id": "dark_green",
   "name": "Dark Green",
   "color_hex": "#008059",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/filament.json
+++ b/data/formfutura/ABS/easyfil_abs/filament.json
@@ -2,9 +2,12 @@
   "id": "easyfil_abs",
   "name": "EasyFil ABS",
   "diameter_tolerance": 0.02,
-  "density": 1.04,
+  "density": 1.05,
   "min_print_temperature": 230,
   "max_print_temperature": 260,
   "min_bed_temperature": 90,
-  "max_bed_temperature": 110
+  "max_bed_temperature": 110,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256508?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256507?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/ABS/easyfil_abs/grey/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/grey/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175GREY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/grey/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/grey/variant.json
@@ -2,6 +2,7 @@
   "id": "grey",
   "name": "Grey",
   "color_hex": "#8C9099",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/light_blue/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/light_blue/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175LBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/light_blue/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/light_blue/variant.json
@@ -2,6 +2,7 @@
   "id": "light_blue",
   "name": "Light Blue",
   "color_hex": "#39B9DB",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/light_green/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/light_green/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175LGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/light_green/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/light_green/variant.json
@@ -2,6 +2,7 @@
   "id": "light_green",
   "name": "Light Green",
   "color_hex": "#9AED51",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/magenta/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/magenta/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175MGNT-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/magenta/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/magenta/variant.json
@@ -2,6 +2,7 @@
   "id": "magenta",
   "name": "Magenta",
   "color_hex": "#C80181",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/orange/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/orange/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175ORAN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/orange/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/orange/variant.json
@@ -2,6 +2,7 @@
   "id": "orange",
   "name": "Orange",
   "color_hex": "#FF9C66",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/red/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/red/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175REDC-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/red/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/red/variant.json
@@ -2,6 +2,7 @@
   "id": "red",
   "name": "Red",
   "color_hex": "#E31A1F",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/silver/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/silver/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175SLVR-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-285SLVR-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/silver/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/silver/variant.json
@@ -2,6 +2,7 @@
   "id": "silver",
   "name": "Silver",
   "color_hex": "#ABACB0",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/white/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/white/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175WHTE-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/white/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/white/variant.json
@@ -2,6 +2,7 @@
   "id": "white",
   "name": "White",
   "color_hex": "#FFFFFF",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }

--- a/data/formfutura/ABS/easyfil_abs/yellow/sizes.json
+++ b/data/formfutura/ABS/easyfil_abs/yellow/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "EABS-175YLLW-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/easyfil-abs"
+      }
+    ]
   }
 ]

--- a/data/formfutura/ABS/easyfil_abs/yellow/variant.json
+++ b/data/formfutura/ABS/easyfil_abs/yellow/variant.json
@@ -2,6 +2,7 @@
   "id": "yellow",
   "name": "Yellow",
   "color_hex": "#FBE200",
+  "discontinued": false,
   "traits": {
     "filtration_recommended": true
   }


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "EasyFil ABS"
- [~] Updated variant "Black"
- [~] Updated variant "Bronze"
- [~] Updated variant "Brown"
- [~] Updated variant "Dark Blue"
- [~] Updated variant "Dark Green"
- [~] Updated variant "Grey"
- [~] Updated variant "Light Blue"
- [~] Updated variant "Light Green"
- [~] Updated variant "Magenta"
- [~] Updated variant "Orange"
- [~] Updated variant "Red"
- [~] Updated variant "Silver"
- [~] Updated variant "White"
- [~] Updated variant "Yellow"

*Submitted by @Njord-FormFutura via the OFD web editor*