### PR TITLE
Updated FormFutura STYX PA6 variants.

### DIFF
--- a/data/formfutura/PA6/pa6/filament.json
+++ b/data/formfutura/PA6/pa6/filament.json
@@ -1,10 +1,13 @@
 {
   "id": "pa6",
-  "name": "PA6",
+  "name": "STYX PA6",
   "diameter_tolerance": 0.02,
-  "density": 1.14,
-  "min_print_temperature": 250,
-  "max_print_temperature": 290,
-  "min_bed_temperature": 80,
-  "max_bed_temperature": 100
+  "density": 1.15,
+  "min_print_temperature": 255,
+  "max_print_temperature": 285,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110,
+  "data_sheet_url": "https://www.formfutura.com/web/content/281451?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/281453?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/PA6/pa6/luvocom_3f_paht_9825_natural/sizes.json
+++ b/data/formfutura/PA6/pa6/luvocom_3f_paht_9825_natural/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PA6/pa6/luvocom_3f_paht_9825_natural/variant.json
+++ b/data/formfutura/PA6/pa6/luvocom_3f_paht_9825_natural/variant.json
@@ -2,6 +2,7 @@
   "id": "luvocom_3f_paht_9825_natural",
   "name": "LUVOCOM 3F PAHT 9825 Natural",
   "color_hex": "#D9D8DE",
+  "discontinued": true,
   "traits": {
     "high_temperature": true,
     "without_pigments": true

--- a/data/formfutura/PA6/pa6/luvocom_3f_paht_9936_black/sizes.json
+++ b/data/formfutura/PA6/pa6/luvocom_3f_paht_9936_black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PA6/pa6/luvocom_3f_paht_9936_black/variant.json
+++ b/data/formfutura/PA6/pa6/luvocom_3f_paht_9936_black/variant.json
@@ -2,6 +2,7 @@
   "id": "luvocom_3f_paht_9936_black",
   "name": "LUVOCOM 3F PAHT 9936 Black",
   "color_hex": "#000000",
+  "discontinued": true,
   "traits": {
     "high_temperature": true
   }

--- a/data/formfutura/PA6/pa6/luvocom_3f_paht_kk_50056_fr_black/sizes.json
+++ b/data/formfutura/PA6/pa6/luvocom_3f_paht_kk_50056_fr_black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PA6/pa6/luvocom_3f_paht_kk_50056_fr_black/variant.json
+++ b/data/formfutura/PA6/pa6/luvocom_3f_paht_kk_50056_fr_black/variant.json
@@ -2,6 +2,7 @@
   "id": "luvocom_3f_paht_kk_50056_fr_black",
   "name": "LUVOCOM 3F PAHT KK 50056 FR Black",
   "color_hex": "#000000",
+  "discontinued": true,
   "traits": {
     "self_extinguishing": true,
     "high_temperature": true,

--- a/data/formfutura/PA6/pa6/styx_natural/sizes.json
+++ b/data/formfutura/PA6/pa6/styx_natural/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "SX06-175NTRL-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "SX06-175NTRL-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "SX06-175NTRL-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PA6/pa6/styx_natural/variant.json
+++ b/data/formfutura/PA6/pa6/styx_natural/variant.json
@@ -1,7 +1,8 @@
 {
   "id": "styx_natural",
-  "name": "STYX Natural",
+  "name": "Natural",
   "color_hex": "#D9D8DE",
+  "discontinued": false,
   "traits": {
     "without_pigments": true
   }

--- a/data/formfutura/PA6/pa6/styx_signal_white/sizes.json
+++ b/data/formfutura/PA6/pa6/styx_signal_white/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "SX06-175SIWH-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "SX06-175SIWH-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "SX06-175SIWH-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PA6/pa6/styx_signal_white/variant.json
+++ b/data/formfutura/PA6/pa6/styx_signal_white/variant.json
@@ -1,5 +1,6 @@
 {
   "id": "styx_signal_white",
-  "name": "STYX Signal White",
-  "color_hex": "#E6EAEF"
+  "name": "Signal White",
+  "color_hex": "#E6EAEF",
+  "discontinued": false
 }

--- a/data/formfutura/PA6/pa6/styx_traffic_black/sizes.json
+++ b/data/formfutura/PA6/pa6/styx_traffic_black/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "SX06-175TBLK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "SX06-175TBLK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "SX06-175TBLK-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PA6/pa6/styx_traffic_black/variant.json
+++ b/data/formfutura/PA6/pa6/styx_traffic_black/variant.json
@@ -1,5 +1,6 @@
 {
   "id": "styx_traffic_black",
-  "name": "STYX Traffic Black",
-  "color_hex": "#000000"
+  "name": "Traffic Black",
+  "color_hex": "#000000",
+  "discontinued": false
 }


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "STYX PA6"
- [~] Updated variant "LUVOCOM 3F PAHT 9825 Natural"
- [~] Updated variant "LUVOCOM 3F PAHT 9936 Black"
- [~] Updated variant "LUVOCOM 3F PAHT KK 50056 FR Black"
- [~] Updated variant "Natural"
- [~] Updated variant "Signal White"
- [~] Updated variant "Traffic Black"

*Submitted by @Njord-FormFutura via the OFD web editor*