### PR TITLE
Updated FormFutura STYX PA6-CF15 variants.

### DIFF
--- a/data/formfutura/PA6/pa6_cf/filament.json
+++ b/data/formfutura/PA6/pa6_cf/filament.json
@@ -1,0 +1,13 @@
+{
+  "id": "pa6_cf",
+  "name": "STYX PA6-CF15",
+  "diameter_tolerance": 0.02,
+  "density": 1.18,
+  "min_print_temperature": 255,
+  "max_print_temperature": 295,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256638?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/290165?download=true",
+  "discontinued": false
+}

--- a/data/formfutura/PA6/pa6_cf/luvocom_3f_paht_cf_9891_black/sizes.json
+++ b/data/formfutura/PA6/pa6_cf/luvocom_3f_paht_cf_9891_black/sizes.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
+  }
+]

--- a/data/formfutura/PA6/pa6_cf/luvocom_3f_paht_cf_9891_black/variant.json
+++ b/data/formfutura/PA6/pa6_cf/luvocom_3f_paht_cf_9891_black/variant.json
@@ -1,0 +1,11 @@
+{
+  "id": "luvocom_3f_paht_cf_9891_black",
+  "name": "LUVOCOM 3F PAHT CF 9891 Black",
+  "color_hex": "#000000",
+  "discontinued": true,
+  "traits": {
+    "abrasive": true,
+    "high_temperature": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/formfutura/PA6/pa6_cf/styx_cf15_black/sizes.json
+++ b/data/formfutura/PA6/pa6_cf/styx_cf15_black/sizes.json
@@ -1,0 +1,58 @@
+[
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "SX65-175BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-cf15"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "SX65-175BLCK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-cf15"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "SX65-175BLCK-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-cf15"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "SX65-175BLCK-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-cf15"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PA6/pa6_cf/styx_cf15_black/variant.json
+++ b/data/formfutura/PA6/pa6_cf/styx_cf15_black/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "styx_cf15_black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false,
+  "traits": {
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "STYX PA6-CF15"
- [~] Updated variant "Black"
- [~] Updated variant "LUVOCOM 3F PAHT CF 9891 Black"

*Submitted by @Njord-FormFutura via the OFD web editor*