### PR TITLE
Updated FormFutura STYX PA6-GF30 variants.

### DIFF
--- a/data/formfutura/PA6/styx_gf_pa6/filament.json
+++ b/data/formfutura/PA6/styx_gf_pa6/filament.json
@@ -1,10 +1,13 @@
 {
   "id": "styx_gf_pa6",
-  "name": "Styx GF PA6",
+  "name": "Styx PA6-GF30",
   "diameter_tolerance": 0.02,
-  "density": 1.14,
-  "min_print_temperature": 250,
-  "max_print_temperature": 290,
-  "min_bed_temperature": 80,
-  "max_bed_temperature": 100
+  "density": 1.34,
+  "min_print_temperature": 255,
+  "max_print_temperature": 295,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256639?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/290166?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/PA6/styx_gf_pa6/gf30/sizes.json
+++ b/data/formfutura/PA6/styx_gf_pa6/gf30/sizes.json
@@ -1,6 +1,58 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "SX63-175BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "SX63-175BLCK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "SX63-175BLCK-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "SX63-175BLCK-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PA6/styx_gf_pa6/gf30/variant.json
+++ b/data/formfutura/PA6/styx_gf_pa6/gf30/variant.json
@@ -1,7 +1,8 @@
 {
   "id": "gf30",
-  "name": "GF30",
+  "name": "Black",
   "color_hex": "#000000",
+  "discontinued": false,
   "traits": {
     "abrasive": true,
     "contains_glass_fiber": true

--- a/data/formfutura/PA6/styx_gf_pa6/gf30_natural/sizes.json
+++ b/data/formfutura/PA6/styx_gf_pa6/gf30_natural/sizes.json
@@ -1,6 +1,58 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "SX63-175NTRL-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "SX63-175NTRL-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
+  },
+  {
+    "filament_weight": 4500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 785,
+    "article_number": "SX63-175NTRL-04500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
+  },
+  {
+    "filament_weight": 8000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 1040,
+    "article_number": "SX63-175NTRL-08000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/styx-pa6-gf30"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PA6/styx_gf_pa6/gf30_natural/variant.json
+++ b/data/formfutura/PA6/styx_gf_pa6/gf30_natural/variant.json
@@ -1,7 +1,8 @@
 {
   "id": "gf30_natural",
-  "name": "GF30 Natural",
+  "name": "Natural",
   "color_hex": "#DFDFD3",
+  "discontinued": false,
   "traits": {
     "abrasive": true,
     "without_pigments": true,


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "Styx PA6-GF30"
- [~] Updated variant "Black"
- [~] Updated variant "Natural"

*Submitted by @Njord-FormFutura via the OFD web editor*