### PR TITLE
Updated FormFutura LUVOCOM 3F PAHT 9936 variants.

### DIFF
--- a/data/formfutura/PA6/luvocom_3f_paht_9936/black/sizes.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_9936/black/sizes.json
@@ -1,0 +1,44 @@
+[
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PH99-175BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-paht-9936"
+      }
+    ]
+  },
+  {
+    "filament_weight": 200,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 100,
+    "article_number": "PH99-285BLCK-00200",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-paht-9936"
+      }
+    ]
+  },
+  {
+    "filament_weight": 500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PH99-285BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-paht-9936"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PA6/luvocom_3f_paht_9936/black/variant.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_9936/black/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false
+}

--- a/data/formfutura/PA6/luvocom_3f_paht_9936/filament.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_9936/filament.json
@@ -1,0 +1,13 @@
+{
+  "id": "luvocom_3f_paht_9936",
+  "name": "LUVOCOM 3F PAHT 9936",
+  "diameter_tolerance": 0.02,
+  "density": 1.25,
+  "min_print_temperature": 255,
+  "max_print_temperature": 275,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 70,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256551?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256552?download=true",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [+] Created filament "LUVOCOM 3F PAHT 9936"
- [+] Created variant "Black"

*Submitted by @Njord-FormFutura via the OFD web editor*