### PR TITLE
Updated FormFutura LUVOCOM 3F PAHT 9825 variants.

### DIFF
--- a/data/formfutura/PA6/luvocom_3f_paht_9825/filament.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_9825/filament.json
@@ -1,0 +1,13 @@
+{
+  "id": "luvocom_3f_paht_9825",
+  "name": "LUVOCOM 3F PAHT 9825",
+  "diameter_tolerance": 0.02,
+  "density": 1.2,
+  "min_print_temperature": 255,
+  "max_print_temperature": 275,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 70,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256549?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256550?download=true",
+  "discontinued": false
+}

--- a/data/formfutura/PA6/luvocom_3f_paht_9825/natural/sizes.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_9825/natural/sizes.json
@@ -1,0 +1,30 @@
+[
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PH98-175NTRL-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-paht-9825"
+      }
+    ]
+  },
+  {
+    "filament_weight": 500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PH98-285NTRL-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-paht-9825"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PA6/luvocom_3f_paht_9825/natural/variant.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_9825/natural/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "natural",
+  "name": "Natural",
+  "color_hex": "#FFFBE5",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [+] Created filament "LUVOCOM 3F PAHT 9825"
- [+] Created variant "Natural"

*Submitted by @Njord-FormFutura via the OFD web editor*