### PR TITLE
Updated FormFutura LUVOCOM 3F PAHT CF 9891 variants.

### DIFF
--- a/data/formfutura/PA6/luvocom_3f_paht_cf_9891/black/sizes.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_cf_9891/black/sizes.json
@@ -1,0 +1,72 @@
+[
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PHCF-175BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/filaments/luvocom-3f-paht-cf-9891"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "PHCF-175BLCK-01000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/filaments/luvocom-3f-paht-cf-9891"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "PHCF-175BLCK-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/filaments/luvocom-3f-paht-cf-9891"
+      }
+    ]
+  },
+  {
+    "filament_weight": 200,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 100,
+    "article_number": "PHCF-285BLCK-00200",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/filaments/luvocom-3f-paht-cf-9891"
+      }
+    ]
+  },
+  {
+    "filament_weight": 500,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PHCF-285BLCK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/filaments/luvocom-3f-paht-cf-9891"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PA6/luvocom_3f_paht_cf_9891/black/variant.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_cf_9891/black/variant.json
@@ -1,0 +1,9 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false,
+  "traits": {
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/formfutura/PA6/luvocom_3f_paht_cf_9891/filament.json
+++ b/data/formfutura/PA6/luvocom_3f_paht_cf_9891/filament.json
@@ -1,0 +1,13 @@
+{
+  "id": "luvocom_3f_paht_cf_9891",
+  "name": "LUVOCOM 3F PAHT CF 9891",
+  "diameter_tolerance": 0.02,
+  "density": 1.24,
+  "min_print_temperature": 260,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 70,
+  "max_bed_temperature": 80,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256555?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256556?download=true",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [+] Created filament "LUVOCOM 3F PAHT CF 9891"
- [+] Created variant "Black"

*Submitted by @Njord-FormFutura via the OFD web editor*