### PR TITLE
Updated FormFutura LUVOCOM 3F PEEK CF 9676 variants.

### DIFF
--- a/data/formfutura/PEEK/cf_peek/filament.json
+++ b/data/formfutura/PEEK/cf_peek/filament.json
@@ -1,10 +1,13 @@
 {
   "id": "cf_peek",
-  "name": "CF PEEK",
+  "name": "LUVOCOM 3F PEEK CF 9676",
   "diameter_tolerance": 0.02,
-  "density": 1.3,
-  "min_print_temperature": 360,
-  "max_print_temperature": 420,
+  "density": 1.34,
+  "min_print_temperature": 400,
+  "max_print_temperature": 450,
   "min_bed_temperature": 120,
-  "max_bed_temperature": 160
+  "max_bed_temperature": 160,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256579?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256580?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/PEEK/cf_peek/luvocom_3f_cf_9676_black/sizes.json
+++ b/data/formfutura/PEEK/cf_peek/luvocom_3f_cf_9676_black/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PKCF-175CRBK-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-peek-cf-9676"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PEEK/cf_peek/luvocom_3f_cf_9676_black/variant.json
+++ b/data/formfutura/PEEK/cf_peek/luvocom_3f_cf_9676_black/variant.json
@@ -1,8 +1,11 @@
 {
   "id": "luvocom_3f_cf_9676_black",
-  "name": "LUVOCOM 3F CF 9676 Black",
+  "name": "Black",
   "color_hex": "#000000",
+  "discontinued": false,
   "traits": {
-    "low_outgassing": true
+    "abrasive": true,
+    "low_outgassing": true,
+    "contains_carbon_fiber": true
   }
 }


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "LUVOCOM 3F PEEK CF 9676"
- [~] Updated variant "Black"

*Submitted by @Njord-FormFutura via the OFD web editor*