### PR TITLE
Updated FormFutura LUVOCOM 3F PEKK 50082 variants.

### DIFF
--- a/data/formfutura/PEKK/pekk/filament.json
+++ b/data/formfutura/PEKK/pekk/filament.json
@@ -1,10 +1,12 @@
 {
   "id": "pekk",
-  "name": "PEKK",
+  "name": "LUVOCOM 3F PEKK 50082",
   "diameter_tolerance": 0.02,
-  "density": 1.3,
-  "min_print_temperature": 350,
-  "max_print_temperature": 400,
+  "density": 1.27,
+  "min_print_temperature": 320,
+  "max_print_temperature": 360,
   "min_bed_temperature": 120,
-  "max_bed_temperature": 160
+  "max_bed_temperature": 160,
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256583?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/PEKK/pekk/luvocom_3f_50082_natural/sizes.json
+++ b/data/formfutura/PEKK/pekk/luvocom_3f_50082_natural/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 200,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 100,
+    "article_number": "PEKK-175NTRL-00200",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-pekk-50082"
+      }
+    ]
+  },
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 140,
+    "article_number": "PEKK-175NTRL-00500",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/luvocom-3f-pekk-50082"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PEKK/pekk/luvocom_3f_50082_natural/variant.json
+++ b/data/formfutura/PEKK/pekk/luvocom_3f_50082_natural/variant.json
@@ -1,7 +1,8 @@
 {
   "id": "luvocom_3f_50082_natural",
-  "name": "LUVOCOM 3F 50082 Natural",
-  "color_hex": "#EADAC2",
+  "name": "Natural",
+  "color_hex": "#5D4A2D",
+  "discontinued": false,
   "traits": {
     "low_outgassing": true,
     "without_pigments": true


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "LUVOCOM 3F PEKK 50082"
- [~] Updated variant "Natural"

*Submitted by @Njord-FormFutura via the OFD web editor*