### PR TITLE
Created FormFutura ReFill PETG variants.

### DIFF
--- a/data/formfutura/PETG/refill_petg/clear/sizes.json
+++ b/data/formfutura/PETG/refill_petg/clear/sizes.json
@@ -1,0 +1,30 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175CLEA-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 40,
+    "article_number": "RFPE-175CLEA-02000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/clear/variant.json
+++ b/data/formfutura/PETG/refill_petg/clear/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "clear",
+  "name": "Clear",
+  "color_hex": "#D5D3D3",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/filament.json
+++ b/data/formfutura/PETG/refill_petg/filament.json
@@ -1,0 +1,13 @@
+{
+  "id": "refill_petg",
+  "name": "ReFill PETG",
+  "diameter_tolerance": 0.02,
+  "density": 1.29,
+  "min_print_temperature": 220,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 75,
+  "max_bed_temperature": 80,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256624?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256623?download=true",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/iron_grey/sizes.json
+++ b/data/formfutura/PETG/refill_petg/iron_grey/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175IGRY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/iron_grey/variant.json
+++ b/data/formfutura/PETG/refill_petg/iron_grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "iron_grey",
+  "name": "Iron Grey",
+  "color_hex": "#616161",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/light_blue/sizes.json
+++ b/data/formfutura/PETG/refill_petg/light_blue/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175LBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/light_blue/variant.json
+++ b/data/formfutura/PETG/refill_petg/light_blue/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "light_blue",
+  "name": "Light Blue",
+  "color_hex": "#009DFF",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/light_grey/sizes.json
+++ b/data/formfutura/PETG/refill_petg/light_grey/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175LGRY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/light_grey/variant.json
+++ b/data/formfutura/PETG/refill_petg/light_grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "light_grey",
+  "name": "Light Grey",
+  "color_hex": "#A1A1A1",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/signal_blue/sizes.json
+++ b/data/formfutura/PETG/refill_petg/signal_blue/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175SIBU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/signal_blue/variant.json
+++ b/data/formfutura/PETG/refill_petg/signal_blue/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "signal_blue",
+  "name": "Signal Blue",
+  "color_hex": "#0049A8",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/signal_white/sizes.json
+++ b/data/formfutura/PETG/refill_petg/signal_white/sizes.json
@@ -1,0 +1,30 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175SIWH-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 40,
+    "article_number": "RFPE-175SIWH-02000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/signal_white/variant.json
+++ b/data/formfutura/PETG/refill_petg/signal_white/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "signal_white",
+  "name": "Signal White",
+  "color_hex": "#FFFFFF",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/traffic_black/sizes.json
+++ b/data/formfutura/PETG/refill_petg/traffic_black/sizes.json
@@ -1,0 +1,30 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175TBLK-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 40,
+    "article_number": "RFPE-175TBLK-02000",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/traffic_black/variant.json
+++ b/data/formfutura/PETG/refill_petg/traffic_black/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "traffic_black",
+  "name": "Traffic Black",
+  "color_hex": "#000000",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/traffic_green/sizes.json
+++ b/data/formfutura/PETG/refill_petg/traffic_green/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175TGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/traffic_green/variant.json
+++ b/data/formfutura/PETG/refill_petg/traffic_green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "traffic_green",
+  "name": "Traffic Green",
+  "color_hex": "#70E177",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/traffic_red/sizes.json
+++ b/data/formfutura/PETG/refill_petg/traffic_red/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175TRRD-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/traffic_red/variant.json
+++ b/data/formfutura/PETG/refill_petg/traffic_red/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "traffic_red",
+  "name": "Traffic Red",
+  "color_hex": "#FF0000",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/yellow_green/sizes.json
+++ b/data/formfutura/PETG/refill_petg/yellow_green/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175YLGN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/yellow_green/variant.json
+++ b/data/formfutura/PETG/refill_petg/yellow_green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "yellow_green",
+  "name": "Yellow Green",
+  "color_hex": "#A6FF00",
+  "discontinued": false
+}

--- a/data/formfutura/PETG/refill_petg/zinc_yellow/sizes.json
+++ b/data/formfutura/PETG/refill_petg/zinc_yellow/sizes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 20,
+    "article_number": "RFPE-175ZYLW-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/refill-petg"
+      }
+    ]
+  }
+]

--- a/data/formfutura/PETG/refill_petg/zinc_yellow/variant.json
+++ b/data/formfutura/PETG/refill_petg/zinc_yellow/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "zinc_yellow",
+  "name": "Zinc Yellow",
+  "color_hex": "#FFF700",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [+] Created filament "ReFill PETG"
- [+] Created variant "Traffic Black"
- [+] Created variant "Signal White"
- [+] Created variant "Light Grey"
- [+] Created variant "Iron Grey"
- [+] Created variant "Clear"
- [+] Created variant "Light Blue"
- [+] Created variant "Signal Blue"
- [+] Created variant "Traffic Green"
- [+] Created variant "Traffic Red"
- [+] Created variant "Yellow Green"
- [+] Created variant "Zinc Yellow"

*Submitted by @Njord-FormFutura via the OFD web editor*