### PR TITLE
feat(bambu): fix support material names

### DIFF
--- a/data/bambu_lab/PVA/for_abs/filament.json
+++ b/data/bambu_lab/PVA/for_abs/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_abs",
-    "name": "PVA for ABS",
+    "name": "Support for ABS",
     "diameter_tolerance": 0.05,
     "density": 1.16,
     "data_sheet_url": "https://cdn.shopify.com/s/files/1/0584/7236/6216/files/Bambus_Support_for_ABS_Technical_Data_Sheet.pdf?v=1721786140",

--- a/data/bambu_lab/PVA/for_pa_pet/filament.json
+++ b/data/bambu_lab/PVA/for_pa_pet/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_pa_pet",
-    "name": "Support For PA/PET",
+    "name": "Support for PA/PET",
     "diameter_tolerance": 0.03,
     "density": 1.17,
     "data_sheet_url": "https://cdn.shopifycdn.net/s/files/1/0584/7236/6216/files/Bambu_Support_for_PA_and_PET_Technical_Data_Sheet.pdf",

--- a/data/bambu_lab/PVA/for_pa_pet/filament.json
+++ b/data/bambu_lab/PVA/for_pa_pet/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_pa_pet",
-    "name": "PVA for PA/PET",
+    "name": "Support For PA/PET",
     "diameter_tolerance": 0.03,
     "density": 1.17,
     "data_sheet_url": "https://cdn.shopifycdn.net/s/files/1/0584/7236/6216/files/Bambu_Support_for_PA_and_PET_Technical_Data_Sheet.pdf",

--- a/data/bambu_lab/PVA/for_pla/filament.json
+++ b/data/bambu_lab/PVA/for_pla/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_pla",
-    "name": "Support For PLA",
+    "name": "Support for PLA",
     "diameter_tolerance": 0.05,
     "density": 1.33,
     "max_dry_temperature": 55,

--- a/data/bambu_lab/PVA/for_pla/filament.json
+++ b/data/bambu_lab/PVA/for_pla/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_pla",
-    "name": "PVA for PLA",
+    "name": "Support For PLA",
     "diameter_tolerance": 0.05,
     "density": 1.33,
     "max_dry_temperature": 55,

--- a/data/bambu_lab/PVA/for_pla_petg/filament.json
+++ b/data/bambu_lab/PVA/for_pla_petg/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_pla_petg",
-    "name": "PVA for PLA/PETG",
+    "name": "Support For PLA/PETG",
     "diameter_tolerance": 0.05,
     "density": 1.28,
     "data_sheet_url": "https://cdn.shopify.com/s/files/1/0584/7236/6216/files/Bambu_Support_for_PLA_PETG_Technical_Data_Sheet.pdf?v=1721103305",

--- a/data/bambu_lab/PVA/for_pla_petg/filament.json
+++ b/data/bambu_lab/PVA/for_pla_petg/filament.json
@@ -1,6 +1,6 @@
 {
     "id": "for_pla_petg",
-    "name": "Support For PLA/PETG",
+    "name": "Support for PLA/PETG",
     "diameter_tolerance": 0.05,
     "density": 1.28,
     "data_sheet_url": "https://cdn.shopify.com/s/files/1/0584/7236/6216/files/Bambu_Support_for_PLA_PETG_Technical_Data_Sheet.pdf?v=1721103305",


### PR DESCRIPTION
Fix badly named Support materials, from "PVA for ..." to "Support for" again.