### PR TITLE
Updated FormFutura Galaxy PLA variants.

### DIFF
--- a/data/formfutura/PLA/galaxy_pla/andromeda_purple/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/andromeda_purple/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175APUR-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285APUR-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/andromeda_purple/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/andromeda_purple/variant.json
@@ -2,6 +2,7 @@
   "id": "andromeda_purple",
   "name": "Andromeda Purple",
   "color_hex": "#9F6979",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/callisto_yellow/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/callisto_yellow/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175CLYL-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285CLYL-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/callisto_yellow/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/callisto_yellow/variant.json
@@ -2,6 +2,7 @@
   "id": "callisto_yellow",
   "name": "Callisto Yellow",
   "color_hex": "#C4C67D",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/champagne_gold/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/champagne_gold/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175CGLD-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "GPLA-175CGLD-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/champagne_gold/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/champagne_gold/variant.json
@@ -2,6 +2,7 @@
   "id": "champagne_gold",
   "name": "Champagne Gold",
   "color_hex": "#ACA078",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/emerald_green/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/emerald_green/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175EGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285EGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/emerald_green/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/emerald_green/variant.json
@@ -2,6 +2,7 @@
   "id": "emerald_green",
   "name": "Emerald Green",
   "color_hex": "#3D9441",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/filament.json
+++ b/data/formfutura/PLA/galaxy_pla/filament.json
@@ -3,8 +3,11 @@
   "name": "Galaxy PLA",
   "diameter_tolerance": 0.02,
   "density": 1.24,
-  "min_print_temperature": 190,
-  "max_print_temperature": 230,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
   "min_bed_temperature": 50,
-  "max_bed_temperature": 70
+  "max_bed_temperature": 60,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256560?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256559?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/PLA/galaxy_pla/gemini_blue/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/gemini_blue/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175GBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285GBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/gemini_blue/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/gemini_blue/variant.json
@@ -2,6 +2,7 @@
   "id": "gemini_blue",
   "name": "Gemini Blue",
   "color_hex": "#5A6A92",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/jupiter_brown/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/jupiter_brown/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175JBRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285JBRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/jupiter_brown/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/jupiter_brown/variant.json
@@ -2,6 +2,7 @@
   "id": "jupiter_brown",
   "name": "Jupiter Brown",
   "color_hex": "#C38C7B",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/mercury_brown/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/mercury_brown/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175MBRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285MBRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/mercury_brown/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/mercury_brown/variant.json
@@ -2,6 +2,7 @@
   "id": "mercury_brown",
   "name": "Mercury Brown",
   "color_hex": "#8E5850",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/opal_green/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/opal_green/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175OGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285OGRN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/opal_green/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/opal_green/variant.json
@@ -2,6 +2,7 @@
   "id": "opal_green",
   "name": "Opal Green",
   "color_hex": "#488D94",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/orion_blue/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/orion_blue/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175OBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "GPLA-175OBLU-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285OBLU-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/orion_blue/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/orion_blue/variant.json
@@ -2,6 +2,7 @@
   "id": "orion_blue",
   "name": "Orion Blue",
   "color_hex": "#626D9B",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/ruby_red/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/ruby_red/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175RRED-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "GPLA-175RRED-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-285RRED-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/ruby_red/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/ruby_red/variant.json
@@ -2,6 +2,7 @@
   "id": "ruby_red",
   "name": "Ruby Red",
   "color_hex": "#AD4E38",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/space_grey/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/space_grey/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175SPGY-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "GPLA-175SPGY-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/space_grey/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/space_grey/variant.json
@@ -2,6 +2,7 @@
   "id": "space_grey",
   "name": "Space Grey",
   "color_hex": "#76797D",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true

--- a/data/formfutura/PLA/galaxy_pla/titanium_silver/sizes.json
+++ b/data/formfutura/PLA/galaxy_pla/titanium_silver/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "GPLA-175TSLV-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "GPLA-175TSLV-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/galaxy-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/galaxy_pla/titanium_silver/variant.json
+++ b/data/formfutura/PLA/galaxy_pla/titanium_silver/variant.json
@@ -2,6 +2,7 @@
   "id": "titanium_silver",
   "name": "Titanium Silver",
   "color_hex": "#ABACB0",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "glitter": true


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [~] Updated filament "Galaxy PLA"
- [~] Updated variant "Andromeda Purple"
- [~] Updated variant "Callisto Yellow"
- [~] Updated variant "Champagne Gold"
- [~] Updated variant "Emerald Green"
- [~] Updated variant "Gemini Blue"
- [~] Updated variant "Jupiter Brown"
- [~] Updated variant "Mercury Brown"
- [~] Updated variant "Opal Green"
- [~] Updated variant "Orion Blue"
- [~] Updated variant "Ruby Red"
- [~] Updated variant "Space Grey"
- [~] Updated variant "Titanium Silver"

*Submitted by @Njord-FormFutura via the OFD web editor*