### PR TITLE
Updated FormFutura High Gloss PLA variants.

### DIFF
--- a/data/formfutura/PLA/high_gloss_silk_pla/blue/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/blue/sizes.json
@@ -1,6 +1,44 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175BLUE-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "HPLA-175BLUE-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-285BLUE-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/blue/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/blue/variant.json
@@ -2,6 +2,7 @@
   "id": "blue",
   "name": "Blue",
   "color_hex": "#0353BA",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/brass/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/brass/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175BRSS-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "HPLA-175BRSS-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/brass/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/brass/variant.json
@@ -2,6 +2,7 @@
   "id": "brass",
   "name": "Brass",
   "color_hex": "#998D58",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/bronze/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/bronze/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175BRNZ-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "HPLA-175BRNZ-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/bronze/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/bronze/variant.json
@@ -2,6 +2,7 @@
   "id": "bronze",
   "name": "Bronze",
   "color_hex": "#8C7547",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_blue_green/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_blue_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_blue_green/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_blue_green/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_blue_green",
   "name": "ColorMorph Blue & Green",
-  "color_hex": [
-    "#008059",
-    "#005DA4"
-  ],
+  "color_hex": "#008059",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_blue_green/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_blue_green/variant.json
@@ -1,7 +1,10 @@
 {
   "id": "colormorph_blue_green",
   "name": "ColorMorph Blue & Green",
-  "color_hex": "#008059",
+  "color_hex": [
+    "#0000ff",
+    "#008059"
+  ],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_gold_silver/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_gold_silver/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_gold_silver/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_gold_silver/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_gold_silver",
   "name": "ColorMorph Gold & Silver",
-  "color_hex": [
-    "#ABACB0",
-    "#CE8D00"
-  ],
+  "color_hex": "#ABACB0",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_gold_silver/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_gold_silver/variant.json
@@ -1,7 +1,10 @@
 {
   "id": "colormorph_gold_silver",
   "name": "ColorMorph Gold & Silver",
-  "color_hex": "#ABACB0",
+  "color_hex": [
+    "#D4AF37",
+    "#ABACB0"
+  ],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_green_magenta/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_green_magenta/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_green_magenta/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_green_magenta/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_green_magenta",
   "name": "ColorMorph Green & Magenta",
-  "color_hex": [
-    "#008059",
-    "#C80181"
-  ],
+  "color_hex": "#008059",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_green_magenta/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_green_magenta/variant.json
@@ -1,7 +1,10 @@
 {
   "id": "colormorph_green_magenta",
   "name": "ColorMorph Green & Magenta",
-  "color_hex": "#008059",
+  "color_hex": [
+    "#008059",
+    "#FF00FF"
+  ],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_magenta_silver/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_magenta_silver/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_magenta_silver/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_magenta_silver/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_magenta_silver",
   "name": "ColorMorph Magenta & Silver",
-  "color_hex": [
-    "#C80181",
-    "#ABACB0"
-  ],
+  "color_hex": "#C80181",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_magenta_silver/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_magenta_silver/variant.json
@@ -1,7 +1,10 @@
 {
   "id": "colormorph_magenta_silver",
   "name": "ColorMorph Magenta & Silver",
-  "color_hex": "#C80181",
+  "color_hex": [
+    "#C80181",
+    "#C0C0C0"
+  ],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_pink_purple/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_pink_purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_pink_purple/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_pink_purple/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_pink_purple",
   "name": "ColorMorph Pink & Purple",
-  "color_hex": [
-    "#B645A9",
-    "#7142A3"
-  ],
+  "color_hex": "#B645A9",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_pink_purple/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_pink_purple/variant.json
@@ -1,7 +1,10 @@
 {
   "id": "colormorph_pink_purple",
   "name": "ColorMorph Pink & Purple",
-  "color_hex": "#B645A9",
+  "color_hex": [
+    "#B645A9",
+    "#800080"
+  ],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_silver_purple/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_silver_purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_silver_purple/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_silver_purple/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_silver_purple",
   "name": "ColorMorph Silver & Purple",
-  "color_hex": [
-    "#ABACB0",
-    "#6C47B2"
-  ],
+  "color_hex": "#ABACB0",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_silver_purple/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_silver_purple/variant.json
@@ -1,7 +1,7 @@
 {
   "id": "colormorph_silver_purple",
   "name": "ColorMorph Silver & Purple",
-  "color_hex": "#ABACB0",
+  "color_hex": ["#ABACB0", "#800080"],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_white_green/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_white_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_white_green/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_white_green/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_white_green",
   "name": "ColorMorph White & Green",
-  "color_hex": [
-    "#4E7642",
-    "#F5F5F4"
-  ],
+  "color_hex": "#4E7642",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_white_green/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_white_green/variant.json
@@ -1,7 +1,7 @@
 {
   "id": "colormorph_white_green",
   "name": "ColorMorph White & Green",
-  "color_hex": "#4E7642",
+  "color_hex": ["#FFFFFF", "#4E7642"],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_yellow_pink/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_yellow_pink/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "spool_refill": false,
+    "discontinued": false
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_yellow_pink/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_yellow_pink/variant.json
@@ -1,10 +1,8 @@
 {
   "id": "colormorph_yellow_pink",
   "name": "ColorMorph Yellow & Pink",
-  "color_hex": [
-    "#FCE575",
-    "#F79DBC"
-  ],
+  "color_hex": "#FCE575",
+  "discontinued": true,
   "traits": {
     "industrially_compostable": true,
     "silk": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/colormorph_yellow_pink/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/colormorph_yellow_pink/variant.json
@@ -1,7 +1,10 @@
 {
   "id": "colormorph_yellow_pink",
   "name": "ColorMorph Yellow & Pink",
-  "color_hex": "#FCE575",
+  "color_hex": [
+    "#FCE575",
+    "#F4A3C0"
+  ],
   "discontinued": true,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/copper/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/copper/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175CPPR-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "HPLA-175CPPR-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/copper/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/copper/variant.json
@@ -2,6 +2,7 @@
   "id": "copper",
   "name": "Copper",
   "color_hex": "#8D5D4F",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/filament.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/filament.json
@@ -1,10 +1,13 @@
 {
   "id": "high_gloss_silk_pla",
-  "name": "High Gloss Silk PLA",
+  "name": "High Gloss PLA",
   "diameter_tolerance": 0.02,
-  "density": 1.24,
-  "min_print_temperature": 190,
-  "max_print_temperature": 230,
-  "min_bed_temperature": 50,
-  "max_bed_temperature": 70
+  "density": 1.22,
+  "min_print_temperature": 210,
+  "max_print_temperature": 240,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 60,
+  "data_sheet_url": "https://www.formfutura.com/web/content/256566?download=true",
+  "safety_sheet_url": "https://www.formfutura.com/web/content/256565?download=true",
+  "discontinued": false
 }

--- a/data/formfutura/PLA/high_gloss_silk_pla/gold/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/gold/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175GOLD-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "HPLA-175GOLD-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/gold/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/gold/variant.json
@@ -2,6 +2,7 @@
   "id": "gold",
   "name": "Gold",
   "color_hex": "#CE8D00",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/green/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/green/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175GREN-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/green/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/green/variant.json
@@ -2,6 +2,7 @@
   "id": "green",
   "name": "Green",
   "color_hex": "#11784F",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/magenta/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/magenta/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175MGNT-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-285MGNT-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/magenta/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/magenta/variant.json
@@ -2,6 +2,7 @@
   "id": "magenta",
   "name": "Magenta",
   "color_hex": "#C80181",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/pink/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/pink/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175PINK-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 750,
+    "diameter": 2.85,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-285PINK-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/pink/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/pink/variant.json
@@ -2,6 +2,7 @@
   "id": "pink",
   "name": "Pink",
   "color_hex": "#FF67F5",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/red/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/red/sizes.json
@@ -4,7 +4,7 @@
     "diameter": 1.75,
     "spool_refill": false,
     "empty_spool_weight": 165,
-    "article_number": "HPLA-175PURP-00750",
+    "article_number": "HPLA-175REDC-00750",
     "discontinued": false,
     "purchase_links": [
       {

--- a/data/formfutura/PLA/high_gloss_silk_pla/red/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/red/variant.json
@@ -1,7 +1,7 @@
 {
-  "id": "purple",
-  "name": "Purple",
-  "color_hex": "#492972",
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#FF0000",
   "discontinued": false,
   "traits": {
     "industrially_compostable": true,

--- a/data/formfutura/PLA/high_gloss_silk_pla/silver/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/silver/sizes.json
@@ -1,6 +1,30 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175SLVR-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
+  },
+  {
+    "filament_weight": 2300,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 625,
+    "article_number": "HPLA-175SLVR-02300",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/silver/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/silver/variant.json
@@ -2,6 +2,7 @@
   "id": "silver",
   "name": "Silver",
   "color_hex": "#ABACB0",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/white/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/white/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175WHTE-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/white/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/white/variant.json
@@ -2,6 +2,7 @@
   "id": "white",
   "name": "White",
   "color_hex": "#FFFFFF",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true

--- a/data/formfutura/PLA/high_gloss_silk_pla/yellow/sizes.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/yellow/sizes.json
@@ -1,6 +1,16 @@
 [
   {
-    "filament_weight": 1000,
-    "diameter": 1.75
+    "filament_weight": 750,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 165,
+    "article_number": "HPLA-175YLLW-00750",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "formfutura",
+        "url": "https://www.formfutura.com/high-gloss-pla"
+      }
+    ]
   }
 ]

--- a/data/formfutura/PLA/high_gloss_silk_pla/yellow/variant.json
+++ b/data/formfutura/PLA/high_gloss_silk_pla/yellow/variant.json
@@ -2,6 +2,7 @@
   "id": "yellow",
   "name": "Yellow",
   "color_hex": "#E4FF33",
+  "discontinued": false,
   "traits": {
     "industrially_compostable": true,
     "silk": true


### PR DESCRIPTION
Also taged the colormorph with discontinued since I will move them.

## Changes
- [~] Updated filament "High Gloss PLA"
- [~] Updated variant "Blue"
- [~] Updated variant "Brass"
- [~] Updated variant "Magenta"
- [~] Updated variant "Pink"
- [~] Updated variant "Bronze"
- [~] Updated variant "ColorMorph Blue & Green"
- [~] Updated variant "ColorMorph Gold & Silver"
- [~] Updated variant "ColorMorph Green & Magenta"
- [~] Updated variant "ColorMorph Magenta & Silver"
- [~] Updated variant "ColorMorph Pink & Purple"
- [~] Updated variant "ColorMorph Silver & Purple"
- [~] Updated variant "ColorMorph White & Green"
- [~] Updated variant "ColorMorph Yellow & Pink"
- [~] Updated variant "Copper"
- [~] Updated variant "Gold"
- [~] Updated variant "Green"
- [~] Updated variant "Purple"
- [~] Updated variant "Silver"
- [~] Updated variant "White"
- [~] Updated variant "Yellow"
- [+] Created variant "Red"

*Submitted by @Njord-FormFutura via the OFD web editor*