### PR TITLE
Update Filament Database

### DIFF
--- a/data/panchroma/PLA/dual_matte_pla/foggy_orange/sizes.json
+++ b/data/panchroma/PLA/dual_matte_pla/foggy_orange/sizes.json
@@ -2,6 +2,9 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "spool_refill": false,
+    "article_number": "CA04045",
+    "discontinued": false,
     "purchase_links": [
       {
         "store_id": "polymaker",

--- a/data/panchroma/PLA/dual_matte_pla/foggy_orange/variant.json
+++ b/data/panchroma/PLA/dual_matte_pla/foggy_orange/variant.json
@@ -1,5 +1,6 @@
 {
-    "id": "foggy_orange",
-    "name": "Foggy Orange",
-    "color_hex": "#C08B55"
+  "id": "foggy_orange",
+  "name": "Foggy Orange",
+  "color_hex": "#C08B55",
+  "discontinued": false
 }

--- a/data/panchroma/PLA/dual_matte_pla/sunrise/sizes.json
+++ b/data/panchroma/PLA/dual_matte_pla/sunrise/sizes.json
@@ -2,6 +2,9 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "spool_refill": false,
+    "article_number": "CA04052",
+    "discontinued": false,
     "purchase_links": [
       {
         "store_id": "polymaker",

--- a/data/panchroma/PLA/dual_matte_pla/sunrise/variant.json
+++ b/data/panchroma/PLA/dual_matte_pla/sunrise/variant.json
@@ -1,5 +1,6 @@
 {
-    "id": "sunrise",
-    "name": "Sunrise",
-    "color_hex": "#F07931"
+  "id": "sunrise",
+  "name": "Sunrise",
+  "color_hex": "#F07931",
+  "discontinued": false
 }

--- a/data/panchroma/PLA/galaxy_pla/galaxy_dark_blue/sizes.json
+++ b/data/panchroma/PLA/galaxy_pla/galaxy_dark_blue/sizes.json
@@ -2,6 +2,10 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "spool_refill": false,
+    "gtin": "6938936714675",
+    "article_number": "CA02025",
+    "discontinued": false,
     "purchase_links": [
       {
         "store_id": "polymaker",

--- a/data/panchroma/PLA/galaxy_pla/galaxy_dark_blue/variant.json
+++ b/data/panchroma/PLA/galaxy_pla/galaxy_dark_blue/variant.json
@@ -1,5 +1,6 @@
 {
-    "id": "galaxy_dark_blue",
-    "name": "Galaxy Dark Blue",
-    "color_hex": "#090C23"
+  "id": "galaxy_dark_blue",
+  "name": "Galaxy Dark Blue",
+  "color_hex": "#090C23",
+  "discontinued": false
 }

--- a/data/panchroma/PLA/galaxy_pla/galaxy_dark_grey/sizes.json
+++ b/data/panchroma/PLA/galaxy_pla/galaxy_dark_grey/sizes.json
@@ -2,6 +2,10 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "spool_refill": false,
+    "gtin": "6938936714705",
+    "article_number": "CA02028",
+    "discontinued": false,
     "purchase_links": [
       {
         "store_id": "polymaker",

--- a/data/panchroma/PLA/galaxy_pla/galaxy_dark_grey/variant.json
+++ b/data/panchroma/PLA/galaxy_pla/galaxy_dark_grey/variant.json
@@ -1,5 +1,6 @@
 {
-    "id": "galaxy_dark_grey",
-    "name": "Galaxy Dark Grey",
-    "color_hex": "#4d5557"
+  "id": "galaxy_dark_grey",
+  "name": "Galaxy Dark Grey",
+  "color_hex": "#4D5557",
+  "discontinued": false
 }

--- a/data/panchroma/PLA/glow_pla/blue/variant.json
+++ b/data/panchroma/PLA/glow_pla/blue/variant.json
@@ -1,5 +1,6 @@
 {
   "id": "blue",
   "name": "Blue",
-  "color_hex": "#0277c5"
+  "color_hex": "#0277C5",
+  "discontinued": false
 }

--- a/data/panchroma/PLA/glow_pla/yellow/sizes.json
+++ b/data/panchroma/PLA/glow_pla/yellow/sizes.json
@@ -3,8 +3,8 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "spool_refill": false,
-    "gtin": "6938936714712",
-    "article_number": "CA02029",
+    "gtin": "6938936714774",
+    "article_number": "CA02035",
     "discontinued": false,
     "purchase_links": [
       {

--- a/data/panchroma/PLA/glow_pla/yellow/variant.json
+++ b/data/panchroma/PLA/glow_pla/yellow/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#EEDC48",
+  "discontinued": false
+}


### PR DESCRIPTION
Added GTIN and article_numbers to some panchroma spools

## Changes
- [~] Updated variant "Galaxy Dark Blue"
- [~] Updated variant "Galaxy Dark Grey"
- [~] Updated variant "Blue"
- [+] Created variant "Yellow"
- [~] Updated variant "Sunrise"
- [~] Updated variant "Foggy Orange"

*Submitted by @hibikipr via the OFD web editor*