### PR TITLE
chore: add .direnv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .env
 .task/
 uid_migration.json
+.direnv/


### PR DESCRIPTION
The project already has a `.envrc` file, but `.direnv/` is missing from `.gitignore`.