### PR TITLE
Add GTIN/EAN and SKU codes for Polymaker filaments

### DIFF
--- a/data/polymaker/ABS/polylite_abs/black/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710158",
+    "article_number": "PE01001"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/blue/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710219",
+    "article_number": "PE01007"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/dark_grey/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/dark_grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936702146",
+    "article_number": "PE01028"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/dark_purple/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/dark_purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713821",
+    "article_number": "PE01054"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/galaxy_black/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/galaxy_black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713746",
+    "article_number": "PE01055"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/galaxy_dark_grey/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/galaxy_dark_grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707950",
+    "article_number": "PE01037"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/galaxy_orange/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/galaxy_orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707936",
+    "article_number": "PE01035"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/galaxy_purple/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/galaxy_purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707943",
+    "article_number": "PE01036"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/galaxy_teal/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/galaxy_teal/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707967",
+    "article_number": "PE01038"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/gold/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/gold/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707240",
+    "article_number": "PE01032"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/green/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710196",
+    "article_number": "PE01005"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/grey/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710172",
+    "article_number": "PE01003"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/light_blue/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/light_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707233",
+    "article_number": "PE01031"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/lime/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/lime/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707226",
+    "article_number": "PE01030"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/natural/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/natural/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936702154",
+    "article_number": "PE01042"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/neon_green/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/neon_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713562",
+    "article_number": "PE01051"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/neon_magenta/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/neon_magenta/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713531",
+    "article_number": "PE01048"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/neon_orange/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/neon_orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713548",
+    "article_number": "PE01049"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/neon_yellow/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/neon_yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713555",
+    "article_number": "PE01050"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/orange/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710233",
+    "article_number": "PE01009"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/pink/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/pink/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707219",
+    "article_number": "PE01029"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/purple/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710226",
+    "article_number": "PE01008"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/red/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710189",
+    "article_number": "PE01004"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/white/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710165",
+    "article_number": "PE01002"
   }
 ]

--- a/data/polymaker/ABS/polylite_abs/yellow/sizes.json
+++ b/data/polymaker/ABS/polylite_abs/yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710202",
+    "article_number": "PE01006"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/army_brown/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/army_brown/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936702153",
+    "article_number": "PF01032"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/army_green/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/army_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710028",
+    "article_number": "PF01009"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/black/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709947",
+    "article_number": "PF01001"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/blue/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709985",
+    "article_number": "PF01005"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/dark_grey/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/dark_grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936708711",
+    "article_number": "PF01037"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/dark_purple/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/dark_purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713852",
+    "article_number": "PF01047"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/galaxy_black/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/galaxy_black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714040",
+    "article_number": "PF01048"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/galaxy_blue/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/galaxy_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707974",
+    "article_number": "PF01034"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/galaxy_green/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/galaxy_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707998",
+    "article_number": "PF01036"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/galaxy_red/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/galaxy_red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707981",
+    "article_number": "PF01035"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/green/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713159",
+    "article_number": "PF01030"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/grey/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709961",
+    "article_number": "PF01003"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/jet_black/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/jet_black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713463",
+    "article_number": "PF01044"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/natural/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/natural/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709992",
+    "article_number": "PF01006"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/olive_brown/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/olive_brown/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713708",
+    "article_number": "PF01045"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/orange/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710004",
+    "article_number": "PF01007"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/polymaker_teal/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/polymaker_teal/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713142",
+    "article_number": "PF01029"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/pop_blue/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/pop_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709381",
+    "article_number": "PF01040"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/pop_green/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/pop_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709404",
+    "article_number": "PF01042"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/pop_pink/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/pop_pink/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709398",
+    "article_number": "PF01041"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/purple/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710011",
+    "article_number": "PF01008"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/red/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709978",
+    "article_number": "PF01004"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/white/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709954",
+    "article_number": "PF01002"
   }
 ]

--- a/data/polymaker/ASA/polylite_asa/yellow/sizes.json
+++ b/data/polymaker/ASA/polylite_asa/yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713166",
+    "article_number": "PF01031"
   }
 ]

--- a/data/polymaker/PC/pc_abs/black/sizes.json
+++ b/data/polymaker/PC/pc_abs/black/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710899",
+    "article_number": "PC04001",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-pc-abs?"
+        "url": "https://us.polymaker.com/products/polymaker-pc-abs"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936712091",
+    "article_number": "PC04003",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-pc-abs?"
+        "url": "https://us.polymaker.com/products/polymaker-pc-abs"
       }
     ]
   }

--- a/data/polymaker/PC/pc_abs/white/sizes.json
+++ b/data/polymaker/PC/pc_abs/white/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710905",
+    "article_number": "PC04002",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-pc-abs?"
+        "url": "https://us.polymaker.com/products/polymaker-pc-abs"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936712107",
+    "article_number": "PC04004",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-pc-abs?"
+        "url": "https://us.polymaker.com/products/polymaker-pc-abs"
       }
     ]
   }

--- a/data/polymaker/PC/polylite_pc/clear/sizes.json
+++ b/data/polymaker/PC/polylite_pc/clear/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710424",
+    "article_number": "PC01001"
   }
 ]

--- a/data/polymaker/PETG/petg/black/sizes.json
+++ b/data/polymaker/PETG/petg/black/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710035",
+    "article_number": "PB01001",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 1.75,
+    "gtin": "6938936707271",
+    "article_number": "PB01043",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,37 +29,43 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711124",
+    "article_number": "PB01014",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 2.85,
+    "gtin": "6938936712602",
+    "article_number": "PB01037",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 5000,
     "diameter": 2.85,
+    "gtin": "6938936707370",
+    "article_number": "PB01045",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/blue/sizes.json
+++ b/data/polymaker/PETG/petg/blue/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710097",
+    "article_number": "PB01007",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +27,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711186",
+    "article_number": "PB01020",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +49,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +59,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/dark_blue/sizes.json
+++ b/data/polymaker/PETG/petg/dark_blue/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936712398",
+    "article_number": "PB01034",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/dark_green/sizes.json
+++ b/data/polymaker/PETG/petg/dark_green/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936712404",
+    "article_number": "PB01035",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/dark_grey/sizes.json
+++ b/data/polymaker/PETG/petg/dark_grey/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936713784",
+    "article_number": "PB01056",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/dark_purple/sizes.json
+++ b/data/polymaker/PETG/petg/dark_purple/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936713791",
+    "article_number": "PB01057",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/electric_blue/sizes.json
+++ b/data/polymaker/PETG/petg/electric_blue/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936707202",
+    "article_number": "PB01042",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/green/sizes.json
+++ b/data/polymaker/PETG/petg/green/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710073",
+    "article_number": "PB01005",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +27,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711162",
+    "article_number": "PB01018",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +49,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +59,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/grey/sizes.json
+++ b/data/polymaker/PETG/petg/grey/sizes.json
@@ -2,40 +2,48 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710059",
+    "article_number": "PB01003",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 1.75,
+    "gtin": "6938936709336",
+    "article_number": "PB01053",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 5000,
     "diameter": 1.75,
+    "gtin": "6938936709244",
+    "article_number": "PB01050",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711148",
+    "article_number": "PB01016",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +53,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +63,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/lime/sizes.json
+++ b/data/polymaker/PETG/petg/lime/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936707196",
+    "article_number": "PB01041",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/magenta/sizes.json
+++ b/data/polymaker/PETG/petg/magenta/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936707172",
+    "article_number": "PB01039",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/orange/sizes.json
+++ b/data/polymaker/PETG/petg/orange/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710110",
+    "article_number": "PB01009",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 1.75,
+    "gtin": "6938936707806",
+    "article_number": "PB01047",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +29,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711209",
+    "article_number": "PB01022",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +51,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +61,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/pink/sizes.json
+++ b/data/polymaker/PETG/petg/pink/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936707189",
+    "article_number": "PB01040",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,7 +27,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -35,7 +37,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +47,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +57,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/purple/sizes.json
+++ b/data/polymaker/PETG/petg/purple/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710103",
+    "article_number": "PB01008",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +27,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711193",
+    "article_number": "PB01021",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +49,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +59,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/red/sizes.json
+++ b/data/polymaker/PETG/petg/red/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710066",
+    "article_number": "PB01004",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 1.75,
+    "gtin": "6938936707813",
+    "article_number": "PB01048",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +29,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711155",
+    "article_number": "PB01017",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +51,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +61,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/silver/sizes.json
+++ b/data/polymaker/PETG/petg/silver/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710141",
+    "article_number": "PB01012",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +27,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711230",
+    "article_number": "PB01025",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +49,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +59,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/teal/sizes.json
+++ b/data/polymaker/PETG/petg/teal/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710127",
+    "article_number": "PB01010",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +27,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711216",
+    "article_number": "PB01023",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +49,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +59,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/white/sizes.json
+++ b/data/polymaker/PETG/petg/white/sizes.json
@@ -2,40 +2,48 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710042",
+    "article_number": "PB01002",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 1.75,
+    "gtin": "6938936709329",
+    "article_number": "PB01052",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 5000,
     "diameter": 1.75,
+    "gtin": "6938936709237",
+    "article_number": "PB01049",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711131",
+    "article_number": "PB01015",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +53,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +63,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/petg/yellow/sizes.json
+++ b/data/polymaker/PETG/petg/yellow/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936710080",
+    "article_number": "PB01006",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -15,7 +17,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -25,17 +27,19 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
   {
     "filament_weight": 1000,
     "diameter": 2.85,
+    "gtin": "6938936711179",
+    "article_number": "PB01019",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -45,7 +49,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   },
@@ -55,7 +59,7 @@
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-petg?"
+        "url": "https://us.polymaker.com/products/polymaker-petg"
       }
     ]
   }

--- a/data/polymaker/PETG/polylite_petg/blue/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710097",
+    "article_number": "PB01007"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/clear/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/clear/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710134",
+    "article_number": "PB01011"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/dark_blue/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/dark_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936712398",
+    "article_number": "PB01034"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/dark_green/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/dark_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936712404",
+    "article_number": "PB01035"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/dark_grey/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/dark_grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713784",
+    "article_number": "PB01056"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/dark_purple/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/dark_purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713791",
+    "article_number": "PB01057"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/electric_blue/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/electric_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707202",
+    "article_number": "PB01042"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/gold/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/gold/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710318",
+    "article_number": "PB01013"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/green/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710073",
+    "article_number": "PB01005"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/grey/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710059",
+    "article_number": "PB01003"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/lime/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/lime/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707196",
+    "article_number": "PB01041"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/magenta/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/magenta/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707172",
+    "article_number": "PB01039"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/orange/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710110",
+    "article_number": "PB01009"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/pink/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/pink/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707189",
+    "article_number": "PB01040"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/purple/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710103",
+    "article_number": "PB01008"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/red/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710066",
+    "article_number": "PB01004"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/silver/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/silver/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710141",
+    "article_number": "PB01012"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/translucent_blue/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/translucent_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936712374",
+    "article_number": "PB01032"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/translucent_green/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/translucent_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936712381",
+    "article_number": "PB01033"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/translucent_red/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/translucent_red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936712367",
+    "article_number": "PB01031"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/white/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710042",
+    "article_number": "PB01002"
   }
 ]

--- a/data/polymaker/PETG/polylite_petg/yellow/sizes.json
+++ b/data/polymaker/PETG/polylite_petg/yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710080",
+    "article_number": "PB01006"
   }
 ]

--- a/data/polymaker/PLA/draft_pla/black/sizes.json
+++ b/data/polymaker/PLA/draft_pla/black/sizes.json
@@ -2,10 +2,12 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "gtin": "6938936713456",
+    "article_number": "PA11004",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polymaker-draft-pla?"
+        "url": "https://us.polymaker.com/products/polymaker-draft-pla"
       }
     ]
   }

--- a/data/polymaker/PLA/lw_polylite_pla/black/sizes.json
+++ b/data/polymaker/PLA/lw_polylite_pla/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709664",
+    "article_number": "PA02001"
   }
 ]

--- a/data/polymaker/PLA/lw_polylite_pla/grey/sizes.json
+++ b/data/polymaker/PLA/lw_polylite_pla/grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709688",
+    "article_number": "PA02003"
   }
 ]

--- a/data/polymaker/PLA/lw_polylite_pla/white/sizes.json
+++ b/data/polymaker/PLA/lw_polylite_pla/white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709671",
+    "article_number": "PA02002"
   }
 ]

--- a/data/polymaker/PLA/metallic_polylite_pla/black/sizes.json
+++ b/data/polymaker/PLA/metallic_polylite_pla/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709664",
+    "article_number": "PA02001"
   }
 ]

--- a/data/polymaker/PLA/metallic_polylite_pla/blue/sizes.json
+++ b/data/polymaker/PLA/metallic_polylite_pla/blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709701",
+    "article_number": "PA02005"
   }
 ]

--- a/data/polymaker/PLA/metallic_polylite_pla/chrome/sizes.json
+++ b/data/polymaker/PLA/metallic_polylite_pla/chrome/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936711018",
+    "article_number": "PA03009"
   }
 ]

--- a/data/polymaker/PLA/polycast/natural/sizes.json
+++ b/data/polymaker/PLA/polycast/natural/sizes.json
@@ -2,40 +2,48 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710936",
+    "article_number": "PJ03001",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polycast?"
+        "url": "https://us.polymaker.com/products/polycast"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 1.75,
+    "gtin": "6938936712848",
+    "article_number": "PJ03003",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polycast?"
+        "url": "https://us.polymaker.com/products/polycast"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712077",
+    "article_number": "PJ03002",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polycast?"
+        "url": "https://us.polymaker.com/products/polycast"
       }
     ]
   },
   {
     "filament_weight": 3000,
     "diameter": 2.85,
+    "gtin": "6938936712855",
+    "article_number": "PJ03004",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polycast?"
+        "url": "https://us.polymaker.com/products/polycast"
       }
     ]
   }

--- a/data/polymaker/PLA/polylite_cf_pla/black/sizes.json
+++ b/data/polymaker/PLA/polylite_cf_pla/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936710264",
+    "article_number": "PA10001"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/aqua_blue/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/aqua_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707080",
+    "article_number": "PA02063"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/azure_blue/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/azure_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707097",
+    "article_number": "PA02064"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/beige/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/beige/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936706960",
+    "article_number": "PA02055"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/black/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709664",
+    "article_number": "PA02001"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/blue/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709701",
+    "article_number": "PA02005"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/brown/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/brown/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936706939",
+    "article_number": "PA02052"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/cold_white/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/cold_white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714132",
+    "article_number": "PA02096"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/cream/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/cream/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936706977",
+    "article_number": "PA02056"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/dark_blue/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/dark_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707615",
+    "article_number": "PA02075"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/dark_grey/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/dark_grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714026",
+    "article_number": "PA02098"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/green/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709718",
+    "article_number": "PA02006"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/grey/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709688",
+    "article_number": "PA02003"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/jungle_green/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/jungle_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707011",
+    "article_number": "PA02059"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/lemon_yellow/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/lemon_yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707066",
+    "article_number": "PA02061"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/lime_green/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/lime_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707028",
+    "article_number": "PA02060"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/magenta/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/magenta/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936706953",
+    "article_number": "PA02054"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/natural/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/natural/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709794",
+    "article_number": "PA02011"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/olive_brown/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/olive_brown/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713685",
+    "article_number": "PA02094"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/olive_green/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/olive_green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936706991",
+    "article_number": "PA02058"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/orange/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709732",
+    "article_number": "PA02008"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/pink/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/pink/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936706946",
+    "article_number": "PA02053"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/polymaker_teal/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/polymaker_teal/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709756",
+    "article_number": "PA02010"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/purple/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709749",
+    "article_number": "PA02009"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/red/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709695",
+    "article_number": "PA02004"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/steel_grey/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/steel_grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707103",
+    "article_number": "PA02065"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/stone_blue/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/stone_blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936707073",
+    "article_number": "PA02062"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/white/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709671",
+    "article_number": "PA02002"
   }
 ]

--- a/data/polymaker/PLA/polylite_pla/yellow/sizes.json
+++ b/data/polymaker/PLA/polylite_pla/yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936709725",
+    "article_number": "PA02007"
   }
 ]

--- a/data/polymaker/PLA/polysmooth/beige/sizes.json
+++ b/data/polymaker/PLA/polysmooth/beige/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710851",
+    "article_number": "PJ01012",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712060",
+    "article_number": "PJ01024",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/black/sizes.json
+++ b/data/polymaker/PLA/polysmooth/black/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710745",
+    "article_number": "PJ01001",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936711957",
+    "article_number": "PJ01013",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/clear/sizes.json
+++ b/data/polymaker/PLA/polysmooth/clear/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710844",
+    "article_number": "PJ01011",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712053",
+    "article_number": "PJ01023",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/coral_red/sizes.json
+++ b/data/polymaker/PLA/polysmooth/coral_red/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710776",
+    "article_number": "PJ01004",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936711988",
+    "article_number": "PJ01016",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/orange/sizes.json
+++ b/data/polymaker/PLA/polysmooth/orange/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710813",
+    "article_number": "PJ01008",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712022",
+    "article_number": "PJ01020",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/pink/sizes.json
+++ b/data/polymaker/PLA/polysmooth/pink/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710820",
+    "article_number": "PJ01009",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712039",
+    "article_number": "PJ01021",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/polymaker_teal/sizes.json
+++ b/data/polymaker/PLA/polysmooth/polymaker_teal/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710837",
+    "article_number": "PJ01010",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712046",
+    "article_number": "PJ01022",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/slate_grey/sizes.json
+++ b/data/polymaker/PLA/polysmooth/slate_grey/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710769",
+    "article_number": "PJ01003",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936711971",
+    "article_number": "PJ01015",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/white/sizes.json
+++ b/data/polymaker/PLA/polysmooth/white/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710752",
+    "article_number": "PJ01002",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936711964",
+    "article_number": "PJ01014",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysmooth/yellow/sizes.json
+++ b/data/polymaker/PLA/polysmooth/yellow/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710806",
+    "article_number": "PJ01007",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712015",
+    "article_number": "PJ01019",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polysmooth?"
+        "url": "https://us.polymaker.com/products/polysmooth"
       }
     ]
   }

--- a/data/polymaker/PLA/polysonic_pla/black/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/black/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713968",
+    "article_number": "PA12002"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/blue/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/blue/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713982",
+    "article_number": "PA12004"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/green/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/green/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714354",
+    "article_number": "PA12010"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/grey/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/grey/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713975",
+    "article_number": "PA12003"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/orange/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/orange/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714286",
+    "article_number": "PA12007"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/polymaker_teal/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/polymaker_teal/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714347",
+    "article_number": "PA12009"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/purple/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/purple/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714293",
+    "article_number": "PA12008"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/red/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/red/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713999",
+    "article_number": "PA12005"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/white/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/white/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936713951",
+    "article_number": "PA12001"
   }
 ]

--- a/data/polymaker/PLA/polysonic_pla/yellow/sizes.json
+++ b/data/polymaker/PLA/polysonic_pla/yellow/sizes.json
@@ -1,6 +1,8 @@
 [
   {
     "filament_weight": 1000,
-    "diameter": 1.75
+    "diameter": 1.75,
+    "gtin": "6938936714279",
+    "article_number": "PA12006"
   }
 ]

--- a/data/polymaker/PVA/polydissolve_s1/natural/sizes.json
+++ b/data/polymaker/PVA/polydissolve_s1/natural/sizes.json
@@ -2,20 +2,24 @@
   {
     "filament_weight": 750,
     "diameter": 1.75,
+    "gtin": "6938936710868",
+    "article_number": "PH01001",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polydissolve-s1?"
+        "url": "https://us.polymaker.com/products/polydissolve-s1"
       }
     ]
   },
   {
     "filament_weight": 750,
     "diameter": 2.85,
+    "gtin": "6938936712084",
+    "article_number": "PH01002",
     "purchase_links": [
       {
         "store_id": "polymaker",
-        "url": "https://us.polymaker.com/products/polydissolve-s1?"
+        "url": "https://us.polymaker.com/products/polydissolve-s1"
       }
     ]
   }


### PR DESCRIPTION
Cross-references Polymaker's official published SKU list (polymaker.com/wp-content/uploads/SKU-PDF-Version-EN-2024-01-1.pdf) against existing Polymaker entries to fill in the gtin and article_number fields on sizes.json, which were previously unset for every Polymaker product. Matched on product line, color name, and size (diameter + weight); only entries with an unambiguous single match were filled, existing data was never overwritten.

Coverage: 187 of 337 Polymaker size entries across 151 files. The remainder are either product lines launched after the source PDF's Jan 2024 publish date (e.g. ABS Pro, ABS Max, most Panchroma sub-lines) or size/weight combinations not listed in the source (e.g. some PolyMax colors only ship in 750g/3kg/5kg per Polymaker's sheet, while this repo lists a 1kg variant for them)