### PR TITLE
Add manufacturer article numbers for Bambu Lab filaments

### DIFF
--- a/data/bambu_lab/ABS/abs/azure/sizes.json
+++ b/data/bambu_lab/ABS/abs/azure/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921128098885",
+    "article_number": "40601",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/bambu_green/sizes.json
+++ b/data/bambu_lab/ABS/abs/bambu_green/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921072925240",
+    "article_number": "40500",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/black/sizes.json
+++ b/data/bambu_lab/ABS/abs/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000.0,
     "diameter": 1.75,
     "ean": "6975337032878",
+    "article_number": "40101",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032878",
+    "article_number": "40101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/blue/sizes.json
+++ b/data/bambu_lab/ABS/abs/blue/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921087642059",
+    "article_number": "40600",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/navy_blue/sizes.json
+++ b/data/bambu_lab/ABS/abs/navy_blue/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921128098884",
+    "article_number": "40602",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/olive/sizes.json
+++ b/data/bambu_lab/ABS/abs/olive/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921128098887",
+    "article_number": "40502",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/orange/sizes.json
+++ b/data/bambu_lab/ABS/abs/orange/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921072925238",
+    "article_number": "40300",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/red/sizes.json
+++ b/data/bambu_lab/ABS/abs/red/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032982",
+    "article_number": "40200",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/silver/sizes.json
+++ b/data/bambu_lab/ABS/abs/silver/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000.0,
     "diameter": 1.75,
     "ean": "6975337032151",
+    "article_number": "40102",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032151",
+    "article_number": "40102",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/tangerine_yellow/sizes.json
+++ b/data/bambu_lab/ABS/abs/tangerine_yellow/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921128098886",
+    "article_number": "40402",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs/white/sizes.json
+++ b/data/bambu_lab/ABS/abs/white/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000.0,
     "diameter": 1.75,
     "ean": "6975337032885",
+    "article_number": "40100",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032885",
+    "article_number": "40100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ABS/abs_gf/black/sizes.json
+++ b/data/bambu_lab/ABS/abs_gf/black/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337037293",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898393224"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337037293",
+    "article_number": "41101",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898393224"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/ABS/abs_gf/blue/sizes.json
+++ b/data/bambu_lab/ABS/abs_gf/blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337037972",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42414474821768"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337037972",
+    "article_number": "41600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42414474821768"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/ABS/abs_gf/gray/sizes.json
+++ b/data/bambu_lab/ABS/abs_gf/gray/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337037255",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898360456"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337037255",
+    "article_number": "41102",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898360456"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/ABS/abs_gf/orange/sizes.json
+++ b/data/bambu_lab/ABS/abs_gf/orange/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337037286",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898163848"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337037286",
+    "article_number": "41300",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898163848"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/ABS/abs_gf/red/sizes.json
+++ b/data/bambu_lab/ABS/abs_gf/red/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337037279",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898229384"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337037279",
+    "article_number": "41200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898229384"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/ABS/abs_gf/white/sizes.json
+++ b/data/bambu_lab/ABS/abs_gf/white/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337037309",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898327688"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337037309",
+    "article_number": "41100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/asa-abs/products/abs-gf?variant=42166898327688"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/ASA/asa/black/sizes.json
+++ b/data/bambu_lab/ASA/asa/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032915",
+    "article_number": "45101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ASA/asa/blue/sizes.json
+++ b/data/bambu_lab/ASA/asa/blue/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921087642072",
+    "article_number": "45600",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ASA/asa/gray/sizes.json
+++ b/data/bambu_lab/ASA/asa/gray/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032939",
+    "article_number": "45102",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ASA/asa/green/sizes.json
+++ b/data/bambu_lab/ASA/asa/green/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921087642070",
+    "article_number": "45500",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ASA/asa/red/sizes.json
+++ b/data/bambu_lab/ASA/asa/red/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921087642069",
+    "article_number": "45200",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/ASA/asa/white/sizes.json
+++ b/data/bambu_lab/ASA/asa/white/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032922",
+    "article_number": "45100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PA6/pa6_cf/black/sizes.json
+++ b/data/bambu_lab/PA6/pa6_cf/black/sizes.json
@@ -1,24 +1,25 @@
 [
-    {
-        "filament_weight": 500,
-        "diameter": 1.75,
-        "ean": "6975337032977",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-cf"
-            }
-        ]
-    },
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921082525998",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-cf?variant=41270316630152"
-            }
-        ]
-    }
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "ean": "6975337032977",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-cf"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921082525998",
+    "article_number": "72100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-cf?variant=41270316630152"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PA6/pa6_gf/black/sizes.json
+++ b/data/bambu_lab/PA6/pa6_gf/black/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135944328"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "72104",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135944328"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PA6/pa6_gf/blue/sizes.json
+++ b/data/bambu_lab/PA6/pa6_gf/blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337036975",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135714952"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337036975",
+    "article_number": "72600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135714952"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PA6/pa6_gf/gray/sizes.json
+++ b/data/bambu_lab/PA6/pa6_gf/gray/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135911560"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "72103",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135911560"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PA6/pa6_gf/orange/sizes.json
+++ b/data/bambu_lab/PA6/pa6_gf/orange/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337036999",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135747720"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337036999",
+    "article_number": "72200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135747720"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PA6/pa6_gf/white/sizes.json
+++ b/data/bambu_lab/PA6/pa6_gf/white/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337036951",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135878792"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337036951",
+    "article_number": "72102",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pa6-gf?variant=41924135878792"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PA6/paht_cf/black/sizes.json
+++ b/data/bambu_lab/PA6/paht_cf/black/sizes.json
@@ -1,24 +1,25 @@
 [
-    {
-        "filament_weight": 500,
-        "diameter": 1.75,
-        "ean": "6975337031833",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/paht-cf"
-            }
-        ]
-    },
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337031840",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/paht-cf?variant=41009450483848"
-            }
-        ]
-    }
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "ean": "6975337031833",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/paht-cf"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337031840",
+    "article_number": "70100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/paht-cf?variant=41009450483848"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PC/pc/black/sizes.json
+++ b/data/bambu_lab/PC/pc/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921072925223",
+    "article_number": "60101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PC/pc/clear_black/sizes.json
+++ b/data/bambu_lab/PC/pc/clear_black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921042539704",
+    "article_number": "60102",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PC/pc/transparent/sizes.json
+++ b/data/bambu_lab/PC/pc/transparent/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921072925224",
+    "article_number": "60103",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PC/pc/white/sizes.json
+++ b/data/bambu_lab/PC/pc/white/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "gtin": "921042539705",
+    "article_number": "60100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PET/pet_cf/black/sizes.json
+++ b/data/bambu_lab/PET/pet_cf/black/sizes.json
@@ -1,24 +1,25 @@
 [
-    {
-        "filament_weight": 500,
-        "diameter": 1.75,
-        "ean": "6975337032250",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pet-cf"
-            }
-        ]
-    },
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032267",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pa-pet/products/pet-cf?variant=41090354380936"
-            }
-        ]
-    }
+  {
+    "filament_weight": 500,
+    "diameter": 1.75,
+    "ean": "6975337032250",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pet-cf"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032267",
+    "article_number": "71100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pa-pet/products/pet-cf?variant=41090354380936"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/hf/black/sizes.json
+++ b/data/bambu_lab/PETG/hf/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337038221",
+    "article_number": "33102",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337038221",
+    "article_number": "33102",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/hf/blue/sizes.json
+++ b/data/bambu_lab/PETG/hf/blue/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337038269",
+    "article_number": "33600",
     "discontinued": true,
     "purchase_links": [
       {

--- a/data/bambu_lab/PETG/hf/gray/sizes.json
+++ b/data/bambu_lab/PETG/hf/gray/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337038214",
+    "article_number": "33101",
     "discontinued": true,
     "purchase_links": [
       {

--- a/data/bambu_lab/PETG/hf/red/sizes.json
+++ b/data/bambu_lab/PETG/hf/red/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337038245",
+    "article_number": "33200",
     "discontinued": true,
     "purchase_links": [
       {

--- a/data/bambu_lab/PETG/hf/white/sizes.json
+++ b/data/bambu_lab/PETG/hf/white/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337038207",
+    "article_number": "33100",
     "discontinued": false,
     "purchase_links": [
       {

--- a/data/bambu_lab/PETG/petg_cf/black/sizes.json
+++ b/data/bambu_lab/PETG/petg_cf/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032243",
+    "article_number": "31100",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032243",
+    "article_number": "31100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/petg_cf/brick_red/sizes.json
+++ b/data/bambu_lab/PETG/petg_cf/brick_red/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032489",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230657978504"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032489",
+    "article_number": "31200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230657978504"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/petg_cf/indigo_blue/sizes.json
+++ b/data/bambu_lab/PETG/petg_cf/indigo_blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032502",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230658011272"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032502",
+    "article_number": "31600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230658011272"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/petg_cf/malachite_green/sizes.json
+++ b/data/bambu_lab/PETG/petg_cf/malachite_green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032519",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230658044040"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032519",
+    "article_number": "31500",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230658044040"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/petg_cf/titan_gray/sizes.json
+++ b/data/bambu_lab/PETG/petg_cf/titan_gray/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337033707",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41392116465800"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337033707",
+    "article_number": "31101",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41392116465800"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/petg_cf/violet_purple/sizes.json
+++ b/data/bambu_lab/PETG/petg_cf/violet_purple/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921092325978",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230657945736"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921092325978",
+    "article_number": "31700",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-cf?variant=41230657945736"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/translucent/clear/sizes.json
+++ b/data/bambu_lab/PETG/translucent/clear/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337038016",
+    "article_number": "32101",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337038016",
+    "article_number": "32101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_brown/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_brown/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337035985",
+    "article_number": "32800",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_gray/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_gray/sizes.json
@@ -1,34 +1,35 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-translucent?variant=41638807961736"
-            }
-        ]
-    },
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "spool_refill": true,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/petg/products/petg-translucent?variant=42828180390024"
-            }
-        ]
-    },
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337035954",
-        "purchase_links": [
-            {
-                "store_id": "3deksperten",
-                "url": "https://3deksperten.dk/products/bambu-lab-petg-translucent-translucent-grey-1-75mm-1kg"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-translucent?variant=41638807961736"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "article_number": "32100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/petg/products/petg-translucent?variant=42828180390024"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337035954",
+    "purchase_links": [
+      {
+        "store_id": "3deksperten",
+        "url": "https://3deksperten.dk/products/bambu-lab-petg-translucent-translucent-grey-1-75mm-1kg"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PETG/translucent/translucent_light_blue/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_light_blue/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337035961",
+    "article_number": "32600",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337035961",
+    "article_number": "32600",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_olive/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_olive/sizes.json
@@ -15,6 +15,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337035978",
+    "article_number": "32500",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_orange/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_orange/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337036005",
+    "article_number": "32300",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_pink/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_pink/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921159956009",
+    "article_number": "32200",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_purple/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_purple/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337036104",
+    "article_number": "32700",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PETG/translucent/translucent_teal/sizes.json
+++ b/data/bambu_lab/PETG/translucent/translucent_teal/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337035992",
+    "article_number": "32501",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337035992",
+    "article_number": "32501",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/bambu_green/sizes.json
+++ b/data/bambu_lab/PLA/basic/bambu_green/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031901",
+    "article_number": "10501",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031901",
+    "article_number": "10501",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/beige/sizes.json
+++ b/data/bambu_lab/PLA/basic/beige/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032335",
+    "article_number": "10201",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/black/sizes.json
+++ b/data/bambu_lab/PLA/basic/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031383",
+    "article_number": "10101",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031383",
+    "article_number": "10101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/blue/sizes.json
+++ b/data/bambu_lab/PLA/basic/blue/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032038",
+    "article_number": "10601",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032038",
+    "article_number": "10601",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/blue_gray/sizes.json
+++ b/data/bambu_lab/PLA/basic/blue_gray/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032342",
+    "article_number": "10602",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/bright_green/sizes.json
+++ b/data/bambu_lab/PLA/basic/bright_green/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252426992",
+    "article_number": "10503",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/bronze/sizes.json
+++ b/data/bambu_lab/PLA/basic/bronze/sizes.json
@@ -15,6 +15,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031918",
+    "article_number": "10801",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/brown/sizes.json
+++ b/data/bambu_lab/PLA/basic/brown/sizes.json
@@ -15,6 +15,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921086642252",
+    "article_number": "10800",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/cobalt_blue/sizes.json
+++ b/data/bambu_lab/PLA/basic/cobalt_blue/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252426961",
+    "article_number": "10604",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/cocoa_brown/sizes.json
+++ b/data/bambu_lab/PLA/basic/cocoa_brown/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252426985",
+    "article_number": "10802",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/cyan/sizes.json
+++ b/data/bambu_lab/PLA/basic/cyan/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032052",
+    "article_number": "10603",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/dark_gray/sizes.json
+++ b/data/bambu_lab/PLA/basic/dark_gray/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "spool_refill": true,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-filament?variant=42844629008520"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "article_number": "10105",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-filament?variant=42844629008520"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic/gold/sizes.json
+++ b/data/bambu_lab/PLA/basic/gold/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031925",
+    "article_number": "10401",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/gray/sizes.json
+++ b/data/bambu_lab/PLA/basic/gray/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032328",
+    "article_number": "10103",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032328",
+    "article_number": "10103",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/hot_pink/sizes.json
+++ b/data/bambu_lab/PLA/basic/hot_pink/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "spool_refill": true,
+    "article_number": "10204",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/indigo_purple/sizes.json
+++ b/data/bambu_lab/PLA/basic/indigo_purple/sizes.json
@@ -2,6 +2,7 @@
   {
     "filament_weight": 1000,
     "diameter": 1.75,
+    "article_number": "10701",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/jade_white/sizes.json
+++ b/data/bambu_lab/PLA/basic/jade_white/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031024",
+    "article_number": "10100",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031024",
+    "article_number": "10100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/light_gray/sizes.json
+++ b/data/bambu_lab/PLA/basic/light_gray/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337039082",
+    "article_number": "10104",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/magenta/sizes.json
+++ b/data/bambu_lab/PLA/basic/magenta/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032045",
+    "article_number": "10202",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/maroon_red/sizes.json
+++ b/data/bambu_lab/PLA/basic/maroon_red/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252427203",
+    "article_number": "10205",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/mistletoe_green/sizes.json
+++ b/data/bambu_lab/PLA/basic/mistletoe_green/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921139781714",
+    "article_number": "10502",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/orange/sizes.json
+++ b/data/bambu_lab/PLA/basic/orange/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252426954",
+    "article_number": "10300",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/pink/sizes.json
+++ b/data/bambu_lab/PLA/basic/pink/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032359",
+    "article_number": "10203",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/pumpkin_orange/sizes.json
+++ b/data/bambu_lab/PLA/basic/pumpkin_orange/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6977252429085",
+    "article_number": "10301",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/purple/sizes.json
+++ b/data/bambu_lab/PLA/basic/purple/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031932",
+    "article_number": "10700",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/red/sizes.json
+++ b/data/bambu_lab/PLA/basic/red/sizes.json
@@ -1,23 +1,25 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-filament?variant=41078274621576"
-            }
-        ]
-    },
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "spool_refill": true,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-filament?variant=40475107000456"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "10200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-filament?variant=41078274621576"
+      }
+    ]
+  },
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "article_number": "10200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-filament?variant=40475107000456"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic/silver/sizes.json
+++ b/data/bambu_lab/PLA/basic/silver/sizes.json
@@ -15,6 +15,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031390",
+    "article_number": "10102",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/sunflower_yellow/sizes.json
+++ b/data/bambu_lab/PLA/basic/sunflower_yellow/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252427197",
+    "article_number": "10402",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/turquoise/sizes.json
+++ b/data/bambu_lab/PLA/basic/turquoise/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6977252427210",
+    "article_number": "10605",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic/yellow/sizes.json
+++ b/data/bambu_lab/PLA/basic/yellow/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031956",
+    "article_number": "10400",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/basic_gradient/arctic_whisper/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/arctic_whisper/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921086537184",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=41215835570312"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921086537184",
+    "article_number": "10900",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=41215835570312"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/blueberry_bubblegum/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/blueberry_bubblegum/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252425339",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301212808"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252425339",
+    "article_number": "10905",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301212808"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/cotton_candy_cloud/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/cotton_candy_cloud/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427111",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301180040"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427111",
+    "article_number": "10907",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301180040"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/dusk_glare/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/dusk_glare/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252426268",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43176275312776"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252426268",
+    "article_number": "10906",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43176275312776"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/mint_lime/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/mint_lime/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337036517",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301245576"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337036517",
+    "article_number": "10904",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301245576"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/ocean_to_meadow/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/ocean_to_meadow/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032083",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=41215835635848"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032083",
+    "article_number": "10902",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=41215835635848"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/pink_citrus/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/pink_citrus/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337036500",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301278344"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337036500",
+    "article_number": "10903",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=43158301278344"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/basic_gradient/solar_breeze/sizes.json
+++ b/data/bambu_lab/PLA/basic_gradient/solar_breeze/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032076",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=41215835603080"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032076",
+    "article_number": "10901",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-basic-gradient?variant=41215835603080"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/galaxy/brown/sizes.json
+++ b/data/bambu_lab/PLA/galaxy/brown/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921159956012",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260037768"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921159956012",
+    "article_number": "13203",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260037768"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/galaxy/green/sizes.json
+++ b/data/bambu_lab/PLA/galaxy/green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921159956014",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260070536"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921159956014",
+    "article_number": "13503",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260070536"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/galaxy/nebulae/sizes.json
+++ b/data/bambu_lab/PLA/galaxy/nebulae/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337036111",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260103304"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337036111",
+    "article_number": "13504",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260103304"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/galaxy/purple/sizes.json
+++ b/data/bambu_lab/PLA/galaxy/purple/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921159956013",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260168840"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921159956013",
+    "article_number": "13602",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-galaxy?variant=41834260168840"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/glow/blue/sizes.json
+++ b/data/bambu_lab/PLA/glow/blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337033950",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487826568"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337033950",
+    "article_number": "15600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487826568"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/glow/green/sizes.json
+++ b/data/bambu_lab/PLA/glow/green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337033943",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487859336"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337033943",
+    "article_number": "15500",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487859336"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/glow/orange/sizes.json
+++ b/data/bambu_lab/PLA/glow/orange/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337033967",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487793800"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337033967",
+    "article_number": "15300",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487793800"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/glow/pink/sizes.json
+++ b/data/bambu_lab/PLA/glow/pink/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337033929",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487892104"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337033929",
+    "article_number": "15200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487892104"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/glow/yellow/sizes.json
+++ b/data/bambu_lab/PLA/glow/yellow/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337033912",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487924872"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337033912",
+    "article_number": "15400",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-glow?variant=41558487924872"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/marble/red_granite/sizes.json
+++ b/data/bambu_lab/PLA/marble/red_granite/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032113",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-marble?variant=41143160668296"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032113",
+    "article_number": "13201",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-marble?variant=41143160668296"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/marble/white_marble/sizes.json
+++ b/data/bambu_lab/PLA/marble/white_marble/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337031185",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-marble?variant=41003162992776"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337031185",
+    "article_number": "13103",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-marble?variant=41003162992776"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/matte/ash_gray/sizes.json
+++ b/data/bambu_lab/PLA/matte/ash_gray/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031352",
+    "article_number": "11102",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031352",
+    "article_number": "11102",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/charcoal/sizes.json
+++ b/data/bambu_lab/PLA/matte/charcoal/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031338",
+    "article_number": "11101",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031338",
+    "article_number": "11101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/dark_blue/sizes.json
+++ b/data/bambu_lab/PLA/matte/dark_blue/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031871",
+    "article_number": "11602",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/dark_brown/sizes.json
+++ b/data/bambu_lab/PLA/matte/dark_brown/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031895",
+    "article_number": "11801",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/dark_green/sizes.json
+++ b/data/bambu_lab/PLA/matte/dark_green/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031864",
+    "article_number": "11501",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/dark_red/sizes.json
+++ b/data/bambu_lab/PLA/matte/dark_red/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031888",
+    "article_number": "11202",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/desert_tan/sizes.json
+++ b/data/bambu_lab/PLA/matte/desert_tan/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "gtin": "921139781713",
+    "article_number": "11401",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/grass_green/sizes.json
+++ b/data/bambu_lab/PLA/matte/grass_green/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032410",
+    "article_number": "11500",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/ice_blue/sizes.json
+++ b/data/bambu_lab/PLA/matte/ice_blue/sizes.json
@@ -15,6 +15,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031857",
+    "article_number": "11601",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/ivory_white/sizes.json
+++ b/data/bambu_lab/PLA/matte/ivory_white/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031345",
+    "article_number": "11100",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031345",
+    "article_number": "11100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/latte_brown/sizes.json
+++ b/data/bambu_lab/PLA/matte/latte_brown/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032427",
+    "article_number": "11800",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/lemon_yellow/sizes.json
+++ b/data/bambu_lab/PLA/matte/lemon_yellow/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032403",
+    "article_number": "11400",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/lilac_purple/sizes.json
+++ b/data/bambu_lab/PLA/matte/lilac_purple/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032434",
+    "article_number": "11700",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/mandarin_orange/sizes.json
+++ b/data/bambu_lab/PLA/matte/mandarin_orange/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337032380",
+    "article_number": "11300",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032380",
+    "article_number": "11300",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/marine_blue/sizes.json
+++ b/data/bambu_lab/PLA/matte/marine_blue/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031369",
+    "article_number": "11600",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031369",
+    "article_number": "11600",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/sakura_pink/sizes.json
+++ b/data/bambu_lab/PLA/matte/sakura_pink/sizes.json
@@ -4,6 +4,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337032397",
+    "article_number": "11201",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/matte/scarlet_red/sizes.json
+++ b/data/bambu_lab/PLA/matte/scarlet_red/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031376",
+    "article_number": "11200",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031376",
+    "article_number": "11200",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/metal/cobalt_blue/sizes.json
+++ b/data/bambu_lab/PLA/metal/cobalt_blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337030317",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41002951770248"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337030317",
+    "article_number": "13600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41002951770248"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/metal/copper_brown/sizes.json
+++ b/data/bambu_lab/PLA/metal/copper_brown/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921072925226",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41150855577736"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921072925226",
+    "article_number": "13800",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41150855577736"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/metal/iridium_gold/sizes.json
+++ b/data/bambu_lab/PLA/metal/iridium_gold/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337030294",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41002951737480"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337030294",
+    "article_number": "13400",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41002951737480"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/metal/iron_gray/sizes.json
+++ b/data/bambu_lab/PLA/metal/iron_gray/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032090",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41150855610504"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032090",
+    "article_number": "13100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41150855610504"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/metal/oxide_green/sizes.json
+++ b/data/bambu_lab/PLA/metal/oxide_green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337030324",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41002960552072"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337030324",
+    "article_number": "13500",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-metal?variant=41002960552072"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/pla_cf/black/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/black/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337031758",
+    "article_number": "14100",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337031758",
+    "article_number": "14100",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/pla_cf/burgundy_red/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/burgundy_red/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921082526063",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41145212076168"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921082526063",
+    "article_number": "14200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41145212076168"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/pla_cf/iris_purple/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/iris_purple/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921115333082",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41286543245448"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921115333082",
+    "article_number": "14700",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41286543245448"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/pla_cf/jeans_blue/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/jeans_blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032472",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41145212043400"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032472",
+    "article_number": "14600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41145212043400"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/pla_cf/lava_gray/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/lava_gray/sizes.json
@@ -3,6 +3,7 @@
     "filament_weight": 1000,
     "diameter": 1.75,
     "ean": "6975337039990",
+    "article_number": "14101",
     "purchase_links": [
       {
         "store_id": "bblstore",
@@ -15,6 +16,7 @@
     "diameter": 1.75,
     "spool_refill": true,
     "ean": "6975337039990",
+    "article_number": "14101",
     "purchase_links": [
       {
         "store_id": "bblstore",

--- a/data/bambu_lab/PLA/pla_cf/matcha_green/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/matcha_green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921082526004",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41158283591816"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921082526004",
+    "article_number": "14500",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41158283591816"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/pla_cf/royal_blue/sizes.json
+++ b/data/bambu_lab/PLA/pla_cf/royal_blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "gtin": "921115332920",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41286543278216"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "gtin": "921115332920",
+    "article_number": "14601",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-cf?variant=41286543278216"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/baby_blue/sizes.json
+++ b/data/bambu_lab/PLA/silk+/baby_blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427388",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679956616"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427388",
+    "article_number": "13603",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679956616"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/blue/sizes.json
+++ b/data/bambu_lab/PLA/silk+/blue/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427463",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679628936"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427463",
+    "article_number": "13604",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679628936"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/candy_green/sizes.json
+++ b/data/bambu_lab/PLA/silk+/candy_green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427395",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679989384"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427395",
+    "article_number": "13506",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679989384"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/candy_red/sizes.json
+++ b/data/bambu_lab/PLA/silk+/candy_red/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427401",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128680022152"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427401",
+    "article_number": "13205",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128680022152"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/champagne/sizes.json
+++ b/data/bambu_lab/PLA/silk+/champagne/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427371",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679923848"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427371",
+    "article_number": "13404",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679923848"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/gold/sizes.json
+++ b/data/bambu_lab/PLA/silk+/gold/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679792776"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "13405",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679792776"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/mint/sizes.json
+++ b/data/bambu_lab/PLA/silk+/mint/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427340",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679825544"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427340",
+    "article_number": "13507",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679825544"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/pink/sizes.json
+++ b/data/bambu_lab/PLA/silk+/pink/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427449",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679694472"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427449",
+    "article_number": "13207",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679694472"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/purple/sizes.json
+++ b/data/bambu_lab/PLA/silk+/purple/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427456",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679661704"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427456",
+    "article_number": "13702",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679661704"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/rose_gold/sizes.json
+++ b/data/bambu_lab/PLA/silk+/rose_gold/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427364",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679891080"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427364",
+    "article_number": "13206",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679891080"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/silver/sizes.json
+++ b/data/bambu_lab/PLA/silk+/silver/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679760008"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "13109",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679760008"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/titan_gray/sizes.json
+++ b/data/bambu_lab/PLA/silk+/titan_gray/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427357",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679858312"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427357",
+    "article_number": "13108",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679858312"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk+/white/sizes.json
+++ b/data/bambu_lab/PLA/silk+/white/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679727240"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "13110",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-upgrade?variant=43128679727240"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk_dual_color/blue_hawaii_blue_green/sizes.json
+++ b/data/bambu_lab/PLA/silk_dual_color/blue_hawaii_blue_green/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337034094",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533405320"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337034094",
+    "article_number": "13904",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533405320"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk_dual_color/gilded_rose_pink_gold/sizes.json
+++ b/data/bambu_lab/PLA/silk_dual_color/gilded_rose_pink_gold/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337034063",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533307016"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337034063",
+    "article_number": "13901",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533307016"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk_dual_color/midnight_blaze_blue_red/sizes.json
+++ b/data/bambu_lab/PLA/silk_dual_color/midnight_blaze_blue_red/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533339784"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "13902",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533339784"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk_dual_color/neon_city_blue_magenta/sizes.json
+++ b/data/bambu_lab/PLA/silk_dual_color/neon_city_blue_magenta/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337034087",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533372552"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337034087",
+    "article_number": "13903",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=41629533372552"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/silk_dual_color/velvet_eclipse_black_red/sizes.json
+++ b/data/bambu_lab/PLA/silk_dual_color/velvet_eclipse_black_red/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252427234",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=43097174704264"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252427234",
+    "article_number": "13905",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-silk-dual-color?variant=43097174704264"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/sparkle/alpine_green_sparkle/sizes.json
+++ b/data/bambu_lab/PLA/sparkle/alpine_green_sparkle/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337031208",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41002885349512"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337031208",
+    "article_number": "13501",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41002885349512"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/sparkle/classic_gold_sparkle/sizes.json
+++ b/data/bambu_lab/PLA/sparkle/classic_gold_sparkle/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337035947",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=42259081789576"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337035947",
+    "article_number": "13402",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=42259081789576"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/sparkle/crimson_red_sparkle/sizes.json
+++ b/data/bambu_lab/PLA/sparkle/crimson_red_sparkle/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337031215",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41002885382280"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337031215",
+    "article_number": "13200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41002885382280"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/sparkle/onyx_black_sparkle/sizes.json
+++ b/data/bambu_lab/PLA/sparkle/onyx_black_sparkle/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337031192",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41002885415048"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337031192",
+    "article_number": "13101",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41002885415048"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/sparkle/royal_purple_sparkle/sizes.json
+++ b/data/bambu_lab/PLA/sparkle/royal_purple_sparkle/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032120",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41158137577608"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032120",
+    "article_number": "13700",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41158137577608"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/sparkle/slate_gray_sparkle/sizes.json
+++ b/data/bambu_lab/PLA/sparkle/slate_gray_sparkle/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6975337032137",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41158137544840"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6975337032137",
+    "article_number": "13102",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-sparkle?variant=41158137544840"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/wood/black_walnut/sizes.json
+++ b/data/bambu_lab/PLA/wood/black_walnut/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252424769",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075831955592"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252424769",
+    "article_number": "13107",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075831955592"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/wood/classic_birch/sizes.json
+++ b/data/bambu_lab/PLA/wood/classic_birch/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252424752",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832053896"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252424752",
+    "article_number": "13505",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832053896"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/wood/clay_brown/sizes.json
+++ b/data/bambu_lab/PLA/wood/clay_brown/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252424738",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832021128"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252424738",
+    "article_number": "13801",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832021128"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/wood/ochre_yellow/sizes.json
+++ b/data/bambu_lab/PLA/wood/ochre_yellow/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252424660",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832119432"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252424660",
+    "article_number": "13403",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832119432"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/wood/rosewood/sizes.json
+++ b/data/bambu_lab/PLA/wood/rosewood/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252424776",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075831988360"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252424776",
+    "article_number": "13204",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075831988360"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/PLA/wood/white_oak/sizes.json
+++ b/data/bambu_lab/PLA/wood/white_oak/sizes.json
@@ -1,13 +1,14 @@
 [
-    {
-        "filament_weight": 1000,
-        "diameter": 1.75,
-        "ean": "6977252424745",
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832086664"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "ean": "6977252424745",
+    "article_number": "13106",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pla/products/pla-wood?variant=43075832086664"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/95a_hf/black/sizes.json
+++ b/data/bambu_lab/TPU/95a_hf/black/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410377864"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "51100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410377864"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/95a_hf/blue/sizes.json
+++ b/data/bambu_lab/TPU/95a_hf/blue/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410607240"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "51600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410607240"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/95a_hf/gray/sizes.json
+++ b/data/bambu_lab/TPU/95a_hf/gray/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410541704"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "51101",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410541704"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/95a_hf/red/sizes.json
+++ b/data/bambu_lab/TPU/95a_hf/red/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410640008"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "51200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410640008"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/95a_hf/white/sizes.json
+++ b/data/bambu_lab/TPU/95a_hf/white/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410508936"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "51102",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410508936"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/95a_hf/yellow/sizes.json
+++ b/data/bambu_lab/TPU/95a_hf/yellow/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410574472"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "51400",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-95a-hf?variant=41469410574472"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/black/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/black/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884785800"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53101",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884785800"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/blue/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/blue/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884654728"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53600",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884654728"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/gray/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/gray/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884753032"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53102",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884753032"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/neon_green/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/neon_green/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884687496"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53500",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884687496"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/red/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/red/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884589192"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53200",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884589192"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/white/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/white/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884720264"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53100",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884720264"
+      }
+    ]
+  }
 ]

--- a/data/bambu_lab/TPU/for_ams/yellow/sizes.json
+++ b/data/bambu_lab/TPU/for_ams/yellow/sizes.json
@@ -1,12 +1,13 @@
 [
-    {
-        "filament_weight": 1000.0,
-        "diameter": 1.75,
-        "purchase_links": [
-            {
-                "store_id": "bblstore",
-                "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884621960"
-            }
-        ]
-    }
+  {
+    "filament_weight": 1000.0,
+    "diameter": 1.75,
+    "article_number": "53400",
+    "purchase_links": [
+      {
+        "store_id": "bblstore",
+        "url": "https://us.store.bambulab.com/collections/pc-tpu/products/tpu-for-ams?variant=43059884621960"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Cross-references Bambu Lab's own US storefront (us.store.bambulab.com) against existing Bambu Lab entries to fill in article_number on sizes.json. Matched with high precision: each sizes.json entry's existing purchase_links already embeds the exact Shopify variant ID for links to Bambu's own store, so this matches on that ID directly rather than fuzzy color/weight matching, and reads the article number straight out of the variant's official name (e.g. "PLA Basic - Jade White (10100)" -> "10100"). This matches the numbering convention already used by the file's 5 pre-existing article_number values.

No new GTIN/EAN data: this repo's Bambu Lab entries already have substantial EAN coverage from prior contributions, which this PR doesn't touch.

198 of 369 size entries filled across 176 files. The remainder either link to non-Bambu stores only (e.g. regional resellers) with no bblstore purchase_link to match against, or correspond to product lines not covered by this pass (ASA Aero, PLA Aero, PLA Lite, PC FR, Matte ASA CF, and the PVA/Support lines weren't in the 34 filament product pages crawled for this PR).