### PR TITLE
Update filament database Slic3D variants

### DIFF
--- a/data/slic3d/PLA/petg_basic/black/sizes.json
+++ b/data/slic3d/PLA/petg_basic/black/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826034",
+    "article_number": "TL6446",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-black-1-75mm-1kg/p/TL6446"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/black/variant.json
+++ b/data/slic3d/PLA/petg_basic/black/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/blue/sizes.json
+++ b/data/slic3d/PLA/petg_basic/blue/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "TL6449",
+    "article_number": "9319236826096",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-blue-1-75mm-1kg/p/TL6449"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/blue/variant.json
+++ b/data/slic3d/PLA/petg_basic/blue/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#022CAC",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/brown/sizes.json
+++ b/data/slic3d/PLA/petg_basic/brown/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826119",
+    "article_number": "TL6454",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-brown-1-75mm-1kg/p/TL6454"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/brown/variant.json
+++ b/data/slic3d/PLA/petg_basic/brown/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "brown",
+  "name": "Brown",
+  "color_hex": "#522100",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/filament.json
+++ b/data/slic3d/PLA/petg_basic/filament.json
@@ -1,0 +1,12 @@
+{
+  "id": "petg_basic",
+  "name": "PETG Basic",
+  "diameter_tolerance": 0.02,
+  "density": 1.24,
+  "max_dry_temperature": 75,
+  "min_print_temperature": 230,
+  "max_print_temperature": 260,
+  "min_bed_temperature": 65,
+  "max_bed_temperature": 75,
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/green/sizes.json
+++ b/data/slic3d/PLA/petg_basic/green/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826065",
+    "article_number": "TL6450",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-green-1-75mm-1kg/p/TL6450"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/green/variant.json
+++ b/data/slic3d/PLA/petg_basic/green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#008000",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/grey/sizes.json
+++ b/data/slic3d/PLA/petg_basic/grey/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826058",
+    "article_number": "TL6452",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-grey-1-75mm-1kg/p/TL6452"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/grey/variant.json
+++ b/data/slic3d/PLA/petg_basic/grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "grey",
+  "name": "Grey",
+  "color_hex": "#ADAEB1",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/orange/sizes.json
+++ b/data/slic3d/PLA/petg_basic/orange/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826089",
+    "article_number": "TL6453",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-orange-1-75mm-1kg/p/TL6453"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/orange/variant.json
+++ b/data/slic3d/PLA/petg_basic/orange/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "orange",
+  "name": "Orange",
+  "color_hex": "#FF7214",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/red/sizes.json
+++ b/data/slic3d/PLA/petg_basic/red/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826041",
+    "article_number": "TL6448",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-red-1-75mm-1kg/p/TL6448"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/red/variant.json
+++ b/data/slic3d/PLA/petg_basic/red/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#FF0000",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/space_grey/sizes.json
+++ b/data/slic3d/PLA/petg_basic/space_grey/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826133",
+    "article_number": "TL6456",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-space-grey-1-75mm-1kg/p/TL6456"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/space_grey/variant.json
+++ b/data/slic3d/PLA/petg_basic/space_grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "space_grey",
+  "name": "Space Grey",
+  "color_hex": "#4F4F4F",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/transparent/sizes.json
+++ b/data/slic3d/PLA/petg_basic/transparent/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826126",
+    "article_number": "TL6455",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-transparent-1-75mm-1kg/p/TL6455"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/transparent/variant.json
+++ b/data/slic3d/PLA/petg_basic/transparent/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "transparent",
+  "name": "Transparent",
+  "color_hex": "#D6D6D6",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/white/sizes.json
+++ b/data/slic3d/PLA/petg_basic/white/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826027",
+    "article_number": "TL6447",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-white-1-75mm-1kg/p/TL6447"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/white/variant.json
+++ b/data/slic3d/PLA/petg_basic/white/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/petg_basic/yellow/sizes.json
+++ b/data/slic3d/PLA/petg_basic/yellow/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826072",
+    "article_number": "TL6451",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-yellow1-75mm-1kg/p/TL6451"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/petg_basic/yellow/variant.json
+++ b/data/slic3d/PLA/petg_basic/yellow/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#FFFF00",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/apple_green/sizes.json
+++ b/data/slic3d/PLA/pla_basic/apple_green/sizes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "article_number": "TL6481",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-apple-green-1-75mm-1kg-filament/p/TL6481"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/apple_green/variant.json
+++ b/data/slic3d/PLA/pla_basic/apple_green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "apple_green",
+  "name": "Apple Green",
+  "color_hex": "#C8FD77",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/beige/sizes.json
+++ b/data/slic3d/PLA/pla_basic/beige/sizes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "article_number": "TL6479",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-beige-1-75mm-1kg-filament/p/TL6479"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/beige/variant.json
+++ b/data/slic3d/PLA/pla_basic/beige/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "beige",
+  "name": "Beige",
+  "color_hex": "#F6E2C4",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/black/sizes.json
+++ b/data/slic3d/PLA/pla_basic/black/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826287",
+    "article_number": "TL6473",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-black-1-75mm-1kg-filament/p/TL6473"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/black/variant.json
+++ b/data/slic3d/PLA/pla_basic/black/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/cocoa_brown/sizes.json
+++ b/data/slic3d/PLA/pla_basic/cocoa_brown/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "gtin": "9319239826348",
+    "article_number": "TL6477",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-cocoa-brown-1-75mm-1kg-filament/p/TL6477"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/cocoa_brown/variant.json
+++ b/data/slic3d/PLA/pla_basic/cocoa_brown/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "cocoa_brown",
+  "name": "Cocoa Brown",
+  "color_hex": "#4D3319",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/green/sizes.json
+++ b/data/slic3d/PLA/pla_basic/green/sizes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "article_number": "TL6480",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-green-1-75mm-1kg-filament/p/TL6480"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/green/variant.json
+++ b/data/slic3d/PLA/pla_basic/green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#00FF44",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/grey/sizes.json
+++ b/data/slic3d/PLA/pla_basic/grey/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826324",
+    "article_number": "TL6475",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-grey-1-75mm-1kg-filament/p/TL6475"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/grey/variant.json
+++ b/data/slic3d/PLA/pla_basic/grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "grey",
+  "name": "Grey",
+  "color_hex": "#666666",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/pink/sizes.json
+++ b/data/slic3d/PLA/pla_basic/pink/sizes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "article_number": "TL6482",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-pink-1-75mm-1kg-filament/p/TL6482"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/pink/variant.json
+++ b/data/slic3d/PLA/pla_basic/pink/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "pink",
+  "name": "Pink",
+  "color_hex": "#FFB0D8",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/red/sizes.json
+++ b/data/slic3d/PLA/pla_basic/red/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826300",
+    "article_number": "TL6476",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-red-1-75mm-1kg-filament/p/TL6476"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/red/variant.json
+++ b/data/slic3d/PLA/pla_basic/red/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#C80000",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/white/sizes.json
+++ b/data/slic3d/PLA/pla_basic/white/sizes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "article_number": "TL6474",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-white-1-75mm-1kg-filament/p/TL6474"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/white/variant.json
+++ b/data/slic3d/PLA/pla_basic/white/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF",
+  "discontinued": false
+}

--- a/data/slic3d/PLA/pla_basic/yellow/sizes.json
+++ b/data/slic3d/PLA/pla_basic/yellow/sizes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": true,
+    "empty_spool_weight": 0,
+    "spool_core_diameter": 100,
+    "article_number": "TL6478",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-pla-spool-less-yellow-1-75mm-1kg-filament/p/TL6478"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PLA/pla_basic/yellow/variant.json
+++ b/data/slic3d/PLA/pla_basic/yellow/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#FFF000",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [+] Created filament "PETG Basic"
- [+] Created variant "Black"
- [+] Created variant "Blue"
- [+] Created variant "Brown"
- [+] Created variant "Grey"
- [+] Created variant "Space Grey"
- [+] Created variant "Green"
- [+] Created variant "Orange"
- [+] Created variant "Red"
- [+] Created variant "Transparent"
- [+] Created variant "White"
- [+] Created variant "Yellow"
- [+] Created variant "Black"
- [+] Created variant "Apple Green"
- [+] Created variant "Beige"
- [+] Created variant "Cocoa Brown"
- [+] Created variant "Green"
- [+] Created variant "Grey"
- [+] Created variant "Pink"
- [+] Created variant "Red"
- [+] Created variant "White"
- [+] Created variant "Yellow"

*Submitted by @cqrt via the OFD web editor*