### PR TITLE
Update filament database - Slic3D PETG Basic variants

### DIFF
--- a/data/slic3d/PETG/petg_basic/black/sizes.json
+++ b/data/slic3d/PETG/petg_basic/black/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826034",
+    "article_number": "TL6446",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-black-1-75mm-1kg/p/TL6446"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/black/variant.json
+++ b/data/slic3d/PETG/petg_basic/black/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/blue/sizes.json
+++ b/data/slic3d/PETG/petg_basic/blue/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826096",
+    "article_number": "TL6449",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-blue-1-75mm-1kg/p/TL6449"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/blue/variant.json
+++ b/data/slic3d/PETG/petg_basic/blue/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "blue",
+  "name": "Blue",
+  "color_hex": "#022CAC",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/brown/sizes.json
+++ b/data/slic3d/PETG/petg_basic/brown/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826119",
+    "article_number": "TL6454",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-brown-1-75mm-1kg/p/TL6454"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/brown/variant.json
+++ b/data/slic3d/PETG/petg_basic/brown/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "brown",
+  "name": "Brown",
+  "color_hex": "#522100",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/green/sizes.json
+++ b/data/slic3d/PETG/petg_basic/green/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826065",
+    "article_number": "TL6450",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-green-1-75mm-1kg/p/TL6450"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/green/variant.json
+++ b/data/slic3d/PETG/petg_basic/green/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "green",
+  "name": "Green",
+  "color_hex": "#008000",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/grey/sizes.json
+++ b/data/slic3d/PETG/petg_basic/grey/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826058",
+    "article_number": "TL6452",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-grey-1-75mm-1kg/p/TL6452"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/grey/variant.json
+++ b/data/slic3d/PETG/petg_basic/grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "grey",
+  "name": "Grey",
+  "color_hex": "#ADAEB1",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/orange/sizes.json
+++ b/data/slic3d/PETG/petg_basic/orange/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826089",
+    "article_number": "TL6453",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-orange-1-75mm-1kg/p/TL6453"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/orange/variant.json
+++ b/data/slic3d/PETG/petg_basic/orange/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "orange",
+  "name": "Orange",
+  "color_hex": "#FF7214",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/red/sizes.json
+++ b/data/slic3d/PETG/petg_basic/red/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826041",
+    "article_number": "TL6448",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-red-1-75mm-1kg/p/TL6448"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/red/variant.json
+++ b/data/slic3d/PETG/petg_basic/red/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "red",
+  "name": "Red",
+  "color_hex": "#FF0000",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/space_grey/sizes.json
+++ b/data/slic3d/PETG/petg_basic/space_grey/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826133",
+    "article_number": "TL6456",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-space-grey-1-75mm-1kg/p/TL6456"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/space_grey/variant.json
+++ b/data/slic3d/PETG/petg_basic/space_grey/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "space_grey",
+  "name": "Space Grey",
+  "color_hex": "#4F4F4F",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/transparent/sizes.json
+++ b/data/slic3d/PETG/petg_basic/transparent/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826126",
+    "article_number": "TL6455",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-transparent-1-75mm-1kg/p/TL6455"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/transparent/variant.json
+++ b/data/slic3d/PETG/petg_basic/transparent/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "transparent",
+  "name": "Transparent",
+  "color_hex": "#D6D6D6",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/white/sizes.json
+++ b/data/slic3d/PETG/petg_basic/white/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826027",
+    "article_number": "TL6447",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-white-1-75mm-1kg/p/TL6447"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/white/variant.json
+++ b/data/slic3d/PETG/petg_basic/white/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "white",
+  "name": "White",
+  "color_hex": "#FFFFFF",
+  "discontinued": false
+}

--- a/data/slic3d/PETG/petg_basic/yellow/sizes.json
+++ b/data/slic3d/PETG/petg_basic/yellow/sizes.json
@@ -1,0 +1,18 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "empty_spool_weight": 115,
+    "spool_core_diameter": 100,
+    "gtin": "9319236826072",
+    "article_number": "TL6451",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "jaycar_nz",
+        "url": "https://www.jaycar.co.nz/slic3d-petg-filament-yellow1-75mm-1kg/p/TL6451"
+      }
+    ]
+  }
+]

--- a/data/slic3d/PETG/petg_basic/yellow/variant.json
+++ b/data/slic3d/PETG/petg_basic/yellow/variant.json
@@ -1,0 +1,6 @@
+{
+  "id": "yellow",
+  "name": "Yellow",
+  "color_hex": "#FFFF00",
+  "discontinued": false
+}


### PR DESCRIPTION
Submitted via Open Filament Database web editor.

## Changes
- [+] Created variant "Black"
- [+] Created variant "Blue"
- [+] Created variant "Brown"
- [+] Created variant "Grey"
- [+] Created variant "Green"
- [+] Created variant "Orange"
- [+] Created variant "Red"
- [+] Created variant "Space Grey"
- [+] Created variant "Transparent"
- [+] Created variant "White"
- [+] Created variant "Yellow"

*Submitted by @cqrt via the OFD web editor*