### PR TITLE
Add Snapmaker PLA-CF (7 colours)

### DIFF
--- a/data/snapmaker/PLA/pla_cf/black/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/black/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/black/variant.json
+++ b/data/snapmaker/PLA/pla_cf/black/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "black",
+  "name": "Black",
+  "color_hex": "#000000",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/snapmaker/PLA/pla_cf/chestnut_brown/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/chestnut_brown/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/chestnut_brown/variant.json
+++ b/data/snapmaker/PLA/pla_cf/chestnut_brown/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "chestnut_brown",
+  "name": "Chestnut Brown",
+  "color_hex": "#9B7C56",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/snapmaker/PLA/pla_cf/denim_blue/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/denim_blue/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/denim_blue/variant.json
+++ b/data/snapmaker/PLA/pla_cf/denim_blue/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "denim_blue",
+  "name": "Denim Blue",
+  "color_hex": "#49799D",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/snapmaker/PLA/pla_cf/filament.json
+++ b/data/snapmaker/PLA/pla_cf/filament.json
@@ -1,0 +1,15 @@
+{
+  "id": "pla_cf",
+  "name": "PLA-CF",
+  "diameter_tolerance": 0.03,
+  "density": 1.29,
+  "max_dry_temperature": 55,
+  "min_print_temperature": 200,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 35,
+  "max_bed_temperature": 70,
+  "min_chamber_temperature": 25,
+  "max_chamber_temperature": 45,
+  "min_nozzle_diameter": 0.4,
+  "data_sheet_url": "https://s3.us-west-2.amazonaws.com/snapmaker.com/download/manual/Snapmaker+PLA-CF+Technical+Data+Sheet+V1.0.0.pdf"
+}

--- a/data/snapmaker/PLA/pla_cf/graphite_gray/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/graphite_gray/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/graphite_gray/variant.json
+++ b/data/snapmaker/PLA/pla_cf/graphite_gray/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "graphite_gray",
+  "name": "Graphite Gray",
+  "color_hex": "#54555B",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/snapmaker/PLA/pla_cf/matcha_green/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/matcha_green/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/matcha_green/variant.json
+++ b/data/snapmaker/PLA/pla_cf/matcha_green/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "matcha_green",
+  "name": "Matcha Green",
+  "color_hex": "#6F8653",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/snapmaker/PLA/pla_cf/violet_purple/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/violet_purple/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/violet_purple/variant.json
+++ b/data/snapmaker/PLA/pla_cf/violet_purple/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "violet_purple",
+  "name": "Violet Purple",
+  "color_hex": "#725E7C",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}

--- a/data/snapmaker/PLA/pla_cf/wine_red/sizes.json
+++ b/data/snapmaker/PLA/pla_cf/wine_red/sizes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "purchase_links": [
+      {
+        "store_id": "snapmaker",
+        "url": "https://shop.snapmaker.com/products/pla-cf-filament-1kg"
+      }
+    ]
+  }
+]

--- a/data/snapmaker/PLA/pla_cf/wine_red/variant.json
+++ b/data/snapmaker/PLA/pla_cf/wine_red/variant.json
@@ -1,0 +1,10 @@
+{
+  "id": "wine_red",
+  "name": "Wine Red",
+  "color_hex": "#823F2E",
+  "traits": {
+    "matte": true,
+    "abrasive": true,
+    "contains_carbon_fiber": true
+  }
+}


### PR DESCRIPTION
Adds Snapmaker's PLA-CF, released this month, with seven colours.

Everything comes from Snapmaker's own sources, nothing inferred:

| Field | Value | Source |
|---|---|---|
| `diameter_tolerance` | 0.03 mm | PLA-CF TDS V1.0.0, Specifications |
| `density` | 1.29 g/cm3 | PLA-CF TDS V1.0.0, Physical Properties |
| print temperature | 200-250 C | PLA-CF TDS V1.0.0, Recommended Printing Settings |
| bed temperature | 35-70 C | same table |
| chamber temperature | 25-45 C | same table |
| `max_dry_temperature` | 55 C | same table (55 C, 6 h) |
| `min_nozzle_diameter` | 0.4 mm | same table |
| `data_sheet_url` | TDS V1.0.0 PDF | linked from the product page |

Colour hex codes are Snapmaker's own, published in the colour options on the
product page: Wine Red 823F2E, Matcha Green 6F8653, Graphite Gray 54555B,
Violet Purple 725E7C, Chestnut Brown 9B7C56, Denim Blue 49799D, Black 000000.

Traits `abrasive` and `contains_carbon_fiber` are set because the datasheet
warns the filament is abrasive and requires hardened steel hot ends; `matte`
because Snapmaker describes the finish as matte.

Sizes: 1 kg at 1.75 mm, with a purchase link to the Snapmaker store.

UUIDs left empty for CI to assign, per the manual. `ofd validate` passes.

Happy to adjust anything. Contributed by SpoolBites (spoolbites.com).
