### PR TITLE
Add manufacturer print and bed temperatures for 80 filaments

### DIFF
--- a/data/amolen/PEBA/90a_flexible_peba/filament.json
+++ b/data/amolen/PEBA/90a_flexible_peba/filament.json
@@ -3,5 +3,9 @@
   "id": "90a_flexible_peba",
   "name": "90A Flexible PEBA",
   "diameter_tolerance": 0.02,
-  "density": 1.01
+  "density": 1.01,
+  "min_print_temperature": 210,
+  "max_print_temperature": 240,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 60
 }

--- a/data/amolen/PEBA/peba/filament.json
+++ b/data/amolen/PEBA/peba/filament.json
@@ -3,5 +3,9 @@
   "id": "peba",
   "name": "PEBA",
   "diameter_tolerance": 0.02,
-  "density": 1.01
+  "density": 1.01,
+  "min_print_temperature": 210,
+  "max_print_temperature": 240,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 60
 }

--- a/data/colorfabb/PHA/glow_pha/filament.json
+++ b/data/colorfabb/PHA/glow_pha/filament.json
@@ -3,5 +3,9 @@
   "id": "glow_pha",
   "name": "Glow PHA",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 195,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 60
 }

--- a/data/colorfabb/PHA/pha/filament.json
+++ b/data/colorfabb/PHA/pha/filament.json
@@ -3,5 +3,9 @@
   "id": "pha",
   "name": "PHA",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 195,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 60
 }

--- a/data/copymaster/PLA/pla/filament.json
+++ b/data/copymaster/PLA/pla/filament.json
@@ -3,5 +3,9 @@
   "id": "pla",
   "name": "PLA",
   "diameter_tolerance": 0.05,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 200,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 60
 }

--- a/data/fiberlogy/ABS/r_abs/filament.json
+++ b/data/fiberlogy/ABS/r_abs/filament.json
@@ -3,5 +3,9 @@
   "id": "r_abs",
   "name": "R ABS",
   "diameter_tolerance": 0.02,
-  "density": 1.04
+  "density": 1.04,
+  "min_print_temperature": 250,
+  "max_print_temperature": 265,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
 }

--- a/data/fiberlogy/ABS/refill_abs/filament.json
+++ b/data/fiberlogy/ABS/refill_abs/filament.json
@@ -3,5 +3,9 @@
   "id": "refill_abs",
   "name": "Refill ABS",
   "diameter_tolerance": 0.02,
-  "density": 1.04
+  "density": 1.04,
+  "min_print_temperature": 250,
+  "max_print_temperature": 265,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
 }

--- a/data/fiberlogy/ABS/refill_r_abs/filament.json
+++ b/data/fiberlogy/ABS/refill_r_abs/filament.json
@@ -3,5 +3,9 @@
   "id": "refill_r_abs",
   "name": "Refill R ABS",
   "diameter_tolerance": 0.02,
-  "density": 1.04
+  "density": 1.04,
+  "min_print_temperature": 250,
+  "max_print_temperature": 265,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
 }

--- a/data/fiberlogy/PA12/nylon_pa12/filament.json
+++ b/data/fiberlogy/PA12/nylon_pa12/filament.json
@@ -4,6 +4,10 @@
     "name": "Nylon PA12",
     "diameter_tolerance": 0.02,
     "density": 1.01,
+    "min_print_temperature": 255,
+    "max_print_temperature": 270,
+    "min_bed_temperature": 100,
+    "max_bed_temperature": 100,
     "slicer_settings": {
         "prusaslicer": {
             "profile_name": "Fiberlogy Nylon PA12"

--- a/data/fiberlogy/PA6/r_nylon/filament.json
+++ b/data/fiberlogy/PA6/r_nylon/filament.json
@@ -3,5 +3,9 @@
   "id": "r_nylon",
   "name": "PA6 R NYLON",
   "diameter_tolerance": 0.02,
-  "density": 1.01
+  "density": 1.01,
+  "min_print_temperature": 255,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 100
 }

--- a/data/fiberlogy/PCTG/refill_pctg/filament.json
+++ b/data/fiberlogy/PCTG/refill_pctg/filament.json
@@ -3,5 +3,9 @@
   "id": "refill_pctg",
   "name": "Refill PCTG",
   "diameter_tolerance": 0.02,
-  "density": 1.23
+  "density": 1.23,
+  "min_print_temperature": 250,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
 }

--- a/data/fiberlogy/PETG/pet_g_esd/filament.json
+++ b/data/fiberlogy/PETG/pet_g_esd/filament.json
@@ -3,5 +3,9 @@
   "id": "pet_g_esd",
   "name": "PET-G ESD",
   "diameter_tolerance": 0.02,
-  "density": 1.3
+  "density": 1.3,
+  "min_print_temperature": 250,
+  "max_print_temperature": 265,
+  "min_bed_temperature": 85,
+  "max_bed_temperature": 85
 }

--- a/data/fiberlogy/PLA/easy_pla/filament.json
+++ b/data/fiberlogy/PLA/easy_pla/filament.json
@@ -4,6 +4,10 @@
     "name": "Easy PLA",
     "diameter_tolerance": 0.02,
     "density": 1.24,
+    "min_print_temperature": 200,
+    "max_print_temperature": 230,
+    "min_bed_temperature": 50,
+    "max_bed_temperature": 70,
     "slicer_settings": {
         "prusaslicer": {
             "profile_name": "Fiberlogy Easy PLA"

--- a/data/fiberlogy/PLA/refill_easy_pla/filament.json
+++ b/data/fiberlogy/PLA/refill_easy_pla/filament.json
@@ -3,5 +3,9 @@
   "id": "refill_easy_pla",
   "name": "Refill Easy PLA",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 200,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 70
 }

--- a/data/fiberlogy/PP/r_pp/filament.json
+++ b/data/fiberlogy/PP/r_pp/filament.json
@@ -3,5 +3,7 @@
   "id": "r_pp",
   "name": "R PP",
   "diameter_tolerance": 0.02,
-  "density": 1.05
+  "density": 1.05,
+  "min_print_temperature": 220,
+  "max_print_temperature": 250
 }

--- a/data/flashforge/ASA/asa_basic/filament.json
+++ b/data/flashforge/ASA/asa_basic/filament.json
@@ -5,6 +5,10 @@
     "diameter_tolerance": 0.02,
     "density": 1.08,
     "max_dry_temperature": 80,
+    "min_print_temperature": 240,
+    "max_print_temperature": 260,
+    "min_bed_temperature": 100,
+    "max_bed_temperature": 120,
     "slicer_settings": {
         "orcaslicer": {
             "generic_id": "GFB98",

--- a/data/polar_filament/PHA/biodegradable_pha/filament.json
+++ b/data/polar_filament/PHA/biodegradable_pha/filament.json
@@ -3,5 +3,9 @@
   "id": "biodegradable_pha",
   "name": "Biodegradable Pha",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 195,
+  "max_print_temperature": 210,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 0
 }

--- a/data/polymide/PA6/copa/filament.json
+++ b/data/polymide/PA6/copa/filament.json
@@ -3,5 +3,9 @@
   "id": "copa",
   "name": "PA6 CoPa",
   "diameter_tolerance": 0.02,
-  "density": 1.12
+  "density": 1.12,
+  "min_print_temperature": 250,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 25,
+  "max_bed_temperature": 50
 }

--- a/data/smart_materials_3d/PVDF/pvdf/filament.json
+++ b/data/smart_materials_3d/PVDF/pvdf/filament.json
@@ -3,5 +3,9 @@
   "id": "pvdf",
   "name": "PVDF",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 220,
+  "max_print_temperature": 260,
+  "min_bed_temperature": 70,
+  "max_bed_temperature": 90
 }

--- a/data/spectrum/ABS/abs_fr_v0/filament.json
+++ b/data/spectrum/ABS/abs_fr_v0/filament.json
@@ -3,5 +3,9 @@
   "id": "abs_fr_v0",
   "name": "ABS FR V0",
   "diameter_tolerance": 0.02,
-  "density": 1.17
+  "density": 1.17,
+  "min_print_temperature": 240,
+  "max_print_temperature": 265,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
 }

--- a/data/spectrum/ABS/abs_gp450/filament.json
+++ b/data/spectrum/ABS/abs_gp450/filament.json
@@ -3,5 +3,9 @@
   "id": "abs_gp450",
   "name": "ABS GP450",
   "diameter_tolerance": 0.02,
-  "density": 1.04
+  "density": 1.04,
+  "min_print_temperature": 235,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 100
 }

--- a/data/spectrum/ABS/abs_kevlar/filament.json
+++ b/data/spectrum/ABS/abs_kevlar/filament.json
@@ -3,5 +3,9 @@
   "id": "abs_kevlar",
   "name": "ABS Kevlar",
   "diameter_tolerance": 0.02,
-  "density": 1.05
+  "density": 1.05,
+  "min_print_temperature": 250,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 100
 }

--- a/data/spectrum/ABS/abs_medical/filament.json
+++ b/data/spectrum/ABS/abs_medical/filament.json
@@ -3,5 +3,9 @@
   "id": "abs_medical",
   "name": "ABS Medical",
   "diameter_tolerance": 0.02,
-  "density": 1.06
+  "density": 1.06,
+  "min_print_temperature": 235,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 100
 }

--- a/data/spectrum/ABS/smart_abs/filament.json
+++ b/data/spectrum/ABS/smart_abs/filament.json
@@ -3,5 +3,9 @@
   "id": "smart_abs",
   "name": "smart ABS",
   "diameter_tolerance": 0.02,
-  "density": 1.05
+  "density": 1.05,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 100
 }

--- a/data/spectrum/ASA/asa_275/filament.json
+++ b/data/spectrum/ASA/asa_275/filament.json
@@ -4,6 +4,10 @@
     "name": "ASA 275",
     "diameter_tolerance": 0.02,
     "density": 1.07,
+    "min_print_temperature": 200,
+    "max_print_temperature": 240,
+    "min_bed_temperature": 40,
+    "max_bed_temperature": 60,
     "slicer_settings": {
         "prusaslicer": {
             "profile_name": "Spectrum ASA 275"

--- a/data/spectrum/ASA/asa_kevlar/filament.json
+++ b/data/spectrum/ASA/asa_kevlar/filament.json
@@ -4,6 +4,10 @@
     "name": "ASA Kevlar",
     "diameter_tolerance": 0.02,
     "density": 1.07,
+    "min_print_temperature": 240,
+    "max_print_temperature": 270,
+    "min_bed_temperature": 80,
+    "max_bed_temperature": 100,
     "slicer_settings": {
         "prusaslicer": {
             "profile_name": "Spectrum ASA Kevlar"

--- a/data/spectrum/ASA/asa_x_cf10/filament.json
+++ b/data/spectrum/ASA/asa_x_cf10/filament.json
@@ -3,5 +3,9 @@
   "id": "asa_x_cf10",
   "name": "ASA-X CF10",
   "diameter_tolerance": 0.02,
-  "density": 1.1
+  "density": 1.1,
+  "min_print_temperature": 235,
+  "max_print_temperature": 260,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 110
 }

--- a/data/spectrum/ASA/asa_x_gf10/filament.json
+++ b/data/spectrum/ASA/asa_x_gf10/filament.json
@@ -3,5 +3,9 @@
   "id": "asa_x_gf10",
   "name": "ASA-X GF10",
   "diameter_tolerance": 0.02,
-  "density": 1.11
+  "density": 1.11,
+  "min_print_temperature": 240,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 100
 }

--- a/data/spectrum/HIPS/hips_x/filament.json
+++ b/data/spectrum/HIPS/hips_x/filament.json
@@ -3,5 +3,9 @@
   "id": "hips_x",
   "name": "HIPS-X",
   "diameter_tolerance": 0.02,
-  "density": 1.05
+  "density": 1.05,
+  "min_print_temperature": 230,
+  "max_print_temperature": 245,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 100
 }

--- a/data/spectrum/PA12/pa12_cf15/filament.json
+++ b/data/spectrum/PA12/pa12_cf15/filament.json
@@ -3,5 +3,9 @@
   "id": "pa12_cf15",
   "name": "PA12 CF15",
   "diameter_tolerance": 0.02,
-  "density": 1.07
+  "density": 1.07,
+  "min_print_temperature": 255,
+  "max_print_temperature": 290,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/pa6_cs20_fr_v0/filament.json
+++ b/data/spectrum/PA6/pa6_cs20_fr_v0/filament.json
@@ -3,5 +3,9 @@
   "id": "pa6_cs20_fr_v0",
   "name": "PA6 CS20 FR V0",
   "diameter_tolerance": 0.02,
-  "density": 1.49
+  "density": 1.49,
+  "min_print_temperature": 265,
+  "max_print_temperature": 290,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/pa6_gk10/filament.json
+++ b/data/spectrum/PA6/pa6_gk10/filament.json
@@ -3,5 +3,9 @@
   "id": "pa6_gk10",
   "name": "PA6 GK10",
   "diameter_tolerance": 0.02,
-  "density": 1.01
+  "density": 1.01,
+  "min_print_temperature": 260,
+  "max_print_temperature": 290,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/pa6_low_warp_cf15s/filament.json
+++ b/data/spectrum/PA6/pa6_low_warp_cf15s/filament.json
@@ -3,5 +3,9 @@
   "id": "pa6_low_warp_cf15s",
   "name": "PA6 Low Warp CF15S",
   "diameter_tolerance": 0.02,
-  "density": 1.28
+  "density": 1.28,
+  "min_print_temperature": 250,
+  "max_print_temperature": 280,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/pa6_low_warp_gf30/filament.json
+++ b/data/spectrum/PA6/pa6_low_warp_gf30/filament.json
@@ -3,5 +3,9 @@
   "id": "pa6_low_warp_gf30",
   "name": "PA6 Low Warp GF30",
   "diameter_tolerance": 0.02,
-  "density": 1.34
+  "density": 1.34,
+  "min_print_temperature": 250,
+  "max_print_temperature": 280,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/pa6_neat_bk/filament.json
+++ b/data/spectrum/PA6/pa6_neat_bk/filament.json
@@ -3,5 +3,9 @@
   "id": "pa6_neat_bk",
   "name": "PA6 Neat BK",
   "diameter_tolerance": 0.02,
-  "density": 1.14
+  "density": 1.14,
+  "min_print_temperature": 250,
+  "max_print_temperature": 280,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/pa6_neat_nt/filament.json
+++ b/data/spectrum/PA6/pa6_neat_nt/filament.json
@@ -3,5 +3,9 @@
   "id": "pa6_neat_nt",
   "name": "Pa6 Neat Nt",
   "diameter_tolerance": 0.02,
-  "density": 1.14
+  "density": 1.14,
+  "min_print_temperature": 250,
+  "max_print_temperature": 280,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PA6/thermatech_pa/filament.json
+++ b/data/spectrum/PA6/thermatech_pa/filament.json
@@ -3,5 +3,9 @@
   "id": "thermatech_pa",
   "name": "ThermaTech PA",
   "diameter_tolerance": 0.02,
-  "density": 1.3
+  "density": 1.3,
+  "min_print_temperature": 250,
+  "max_print_temperature": 280,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PC/pc_275/filament.json
+++ b/data/spectrum/PC/pc_275/filament.json
@@ -3,5 +3,9 @@
   "id": "pc_275",
   "name": "PC 275",
   "diameter_tolerance": 0.02,
-  "density": 1.2
+  "density": 1.2,
+  "min_print_temperature": 250,
+  "max_print_temperature": 290,
+  "min_bed_temperature": 90,
+  "max_bed_temperature": 130
 }

--- a/data/spectrum/PCTG/pctg_cf10/filament.json
+++ b/data/spectrum/PCTG/pctg_cf10/filament.json
@@ -3,5 +3,9 @@
   "id": "pctg_cf10",
   "name": "PCTG CF10",
   "diameter_tolerance": 0.02,
-  "density": 1.28
+  "density": 1.28,
+  "min_print_temperature": 250,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 50
 }

--- a/data/spectrum/PCTG/pctg_gf10/filament.json
+++ b/data/spectrum/PCTG/pctg_gf10/filament.json
@@ -3,5 +3,9 @@
   "id": "pctg_gf10",
   "name": "PCTG GF10",
   "diameter_tolerance": 0.02,
-  "density": 1.31
+  "density": 1.31,
+  "min_print_temperature": 250,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 50
 }

--- a/data/spectrum/PET/pet_cf15/filament.json
+++ b/data/spectrum/PET/pet_cf15/filament.json
@@ -3,5 +3,9 @@
   "id": "pet_cf15",
   "name": "PET CF15",
   "diameter_tolerance": 0.02,
-  "density": 1.4
+  "density": 1.4,
+  "min_print_temperature": 245,
+  "max_print_temperature": 270,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 70
 }

--- a/data/spectrum/PETG/petg_carbon/filament.json
+++ b/data/spectrum/PETG/petg_carbon/filament.json
@@ -3,5 +3,9 @@
   "id": "petg_carbon",
   "name": "PETG Carbon",
   "diameter_tolerance": 0.02,
-  "density": 1.32
+  "density": 1.32,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PETG/petg_fr_v0/filament.json
+++ b/data/spectrum/PETG/petg_fr_v0/filament.json
@@ -3,5 +3,9 @@
   "id": "petg_fr_v0",
   "name": "PETG FR V0",
   "diameter_tolerance": 0.02,
-  "density": 1.26
+  "density": 1.26,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PETG/petg_fx120/filament.json
+++ b/data/spectrum/PETG/petg_fx120/filament.json
@@ -3,5 +3,9 @@
   "id": "petg_fx120",
   "name": "PETG FX120",
   "diameter_tolerance": 0.02,
-  "density": 1.13
+  "density": 1.13,
+  "min_print_temperature": 240,
+  "max_print_temperature": 260,
+  "min_bed_temperature": 80,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PETG/petg_glitter/filament.json
+++ b/data/spectrum/PETG/petg_glitter/filament.json
@@ -3,5 +3,9 @@
   "id": "petg_glitter",
   "name": "PETG Glitter",
   "diameter_tolerance": 0.02,
-  "density": 1.27
+  "density": 1.27,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PETG/petg_glow_in_the_dark/filament.json
+++ b/data/spectrum/PETG/petg_glow_in_the_dark/filament.json
@@ -3,5 +3,9 @@
   "id": "petg_glow_in_the_dark",
   "name": "PETG Glow in the Dark",
   "diameter_tolerance": 0.02,
-  "density": 1.27
+  "density": 1.27,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PETG/petg_ht100/filament.json
+++ b/data/spectrum/PETG/petg_ht100/filament.json
@@ -4,6 +4,10 @@
     "name": "PETG HT100",
     "diameter_tolerance": 0.02,
     "density": 1.18,
+    "min_print_temperature": 250,
+    "max_print_temperature": 280,
+    "min_bed_temperature": 100,
+    "max_bed_temperature": 110,
     "slicer_settings": {
         "prusaslicer": {
             "profile_name": "Spectrum PETG HT100"

--- a/data/spectrum/PETG/petg_matt/filament.json
+++ b/data/spectrum/PETG/petg_matt/filament.json
@@ -4,6 +4,10 @@
     "name": "PETG MATT",
     "diameter_tolerance": 0.02,
     "density": 1.35,
+    "min_print_temperature": 230,
+    "max_print_temperature": 255,
+    "min_bed_temperature": 60,
+    "max_bed_temperature": 80,
     "slicer_settings": {
         "prusaslicer": {
             "profile_name": "Spectrum PETG Matt"

--- a/data/spectrum/PETG/petg_premium/filament.json
+++ b/data/spectrum/PETG/petg_premium/filament.json
@@ -3,5 +3,9 @@
   "id": "petg_premium",
   "name": "PETG Premium",
   "diameter_tolerance": 0.02,
-  "density": 1.27
+  "density": 1.27,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PETG/ptfe/filament.json
+++ b/data/spectrum/PETG/ptfe/filament.json
@@ -3,5 +3,9 @@
   "id": "ptfe",
   "name": "PTFE",
   "diameter_tolerance": 0.02,
-  "density": 1.32
+  "density": 1.32,
+  "min_print_temperature": 230,
+  "max_print_temperature": 255,
+  "min_bed_temperature": 60,
+  "max_bed_temperature": 80
 }

--- a/data/spectrum/PLA/aquaprint/filament.json
+++ b/data/spectrum/PLA/aquaprint/filament.json
@@ -3,5 +3,9 @@
   "id": "aquaprint",
   "name": "PLA AquaPrint",
   "diameter_tolerance": 0.02,
-  "density": 0.9
+  "density": 0.9,
+  "min_print_temperature": 190,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 25,
+  "max_bed_temperature": 70
 }

--- a/data/spectrum/PLA/flameguard_pla/filament.json
+++ b/data/spectrum/PLA/flameguard_pla/filament.json
@@ -3,5 +3,9 @@
   "id": "flameguard_pla",
   "name": "FlameGuard PLA",
   "diameter_tolerance": 0.02,
-  "density": 1.26
+  "density": 1.26,
+  "min_print_temperature": 210,
+  "max_print_temperature": 240,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 60
 }

--- a/data/spectrum/PLA/greenyht/filament.json
+++ b/data/spectrum/PLA/greenyht/filament.json
@@ -4,6 +4,10 @@
   "name": "PLA GreenyHT",
   "diameter_tolerance": 0.02,
   "density": 1.54,
+  "min_print_temperature": 190,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45,
   "slicer_settings": {
     "prusaslicer": {
       "profile_name": "Spectrum GreenyHT"

--- a/data/spectrum/PLA/greenypro/filament.json
+++ b/data/spectrum/PLA/greenypro/filament.json
@@ -3,5 +3,9 @@
   "id": "greenypro",
   "name": "PLA GreenyPro",
   "diameter_tolerance": 0.02,
-  "density": 1.34
+  "density": 1.34,
+  "min_print_temperature": 190,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/huracan_pla/filament.json
+++ b/data/spectrum/PLA/huracan_pla/filament.json
@@ -3,5 +3,9 @@
   "id": "huracan_pla",
   "name": "Huracan PLA",
   "diameter_tolerance": 0.02,
-  "density": 1.23
+  "density": 1.23,
+  "min_print_temperature": 190,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/lw_pla_ultrafoam/filament.json
+++ b/data/spectrum/PLA/lw_pla_ultrafoam/filament.json
@@ -3,5 +3,9 @@
   "id": "lw_pla_ultrafoam",
   "name": "LW-PLA UltraFoam",
   "diameter_tolerance": 0.02,
-  "density": 1.23
+  "density": 1.23,
+  "min_print_temperature": 190,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 50
 }

--- a/data/spectrum/PLA/pastello_pla/filament.json
+++ b/data/spectrum/PLA/pastello_pla/filament.json
@@ -3,5 +3,9 @@
   "id": "pastello_pla",
   "name": "Pastello PLA",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 60
 }

--- a/data/spectrum/PLA/pla_carbon/filament.json
+++ b/data/spectrum/PLA/pla_carbon/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_carbon",
   "name": "PLA Carbon",
   "diameter_tolerance": 0.02,
-  "density": 1.3
+  "density": 1.3,
+  "min_print_temperature": 190,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_crystal/filament.json
+++ b/data/spectrum/PLA/pla_crystal/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_crystal",
   "name": "PLA Crystal",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_electrically_conductive/filament.json
+++ b/data/spectrum/PLA/pla_electrically_conductive/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_electrically_conductive",
   "name": "PLA Electrically Conductive",
   "diameter_tolerance": 0.02,
-  "density": 1.35
+  "density": 1.35,
+  "min_print_temperature": 210,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 50
 }

--- a/data/spectrum/PLA/pla_glitter/filament.json
+++ b/data/spectrum/PLA/pla_glitter/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_glitter",
   "name": "PLA Glitter",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_glow_in_the_dark/filament.json
+++ b/data/spectrum/PLA/pla_glow_in_the_dark/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_glow_in_the_dark",
   "name": "PLA Glow in the Dark",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 185,
+  "max_print_temperature": 225,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_magic_silk/filament.json
+++ b/data/spectrum/PLA/pla_magic_silk/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_magic_silk",
   "name": "PLA Magic SILK",
   "diameter_tolerance": 0.02,
-  "density": 1.22
+  "density": 1.22,
+  "min_print_temperature": 210,
+  "max_print_temperature": 240,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 60
 }

--- a/data/spectrum/PLA/pla_matt/filament.json
+++ b/data/spectrum/PLA/pla_matt/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_matt",
   "name": "PLA MATT",
   "diameter_tolerance": 0.02,
-  "density": 1.22
+  "density": 1.22,
+  "min_print_temperature": 190,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_metal/filament.json
+++ b/data/spectrum/PLA/pla_metal/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_metal",
   "name": "PLA Metal",
   "diameter_tolerance": 0.02,
-  "density": 1.22
+  "density": 1.22,
+  "min_print_temperature": 195,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 50
 }

--- a/data/spectrum/PLA/pla_nature/filament.json
+++ b/data/spectrum/PLA/pla_nature/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_nature",
   "name": "PLA Nature",
   "diameter_tolerance": 0.02,
-  "density": 1.25
+  "density": 1.25,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_premium/filament.json
+++ b/data/spectrum/PLA/pla_premium/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_premium",
   "name": "PLA Premium",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_premium_highspeed/filament.json
+++ b/data/spectrum/PLA/pla_premium_highspeed/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_premium_highspeed",
   "name": "PLA Premium HighSpeed",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 190,
+  "max_print_temperature": 250,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_silk_rainbow/filament.json
+++ b/data/spectrum/PLA/pla_silk_rainbow/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_silk_rainbow",
   "name": "PLA SILK Rainbow",
   "diameter_tolerance": 0.02,
-  "density": 1.22
+  "density": 1.22,
+  "min_print_temperature": 210,
+  "max_print_temperature": 240,
+  "min_bed_temperature": 40,
+  "max_bed_temperature": 60
 }

--- a/data/spectrum/PLA/pla_thermoactive/filament.json
+++ b/data/spectrum/PLA/pla_thermoactive/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_thermoactive",
   "name": "PLA Thermoactive",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 190,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/pla_tough/filament.json
+++ b/data/spectrum/PLA/pla_tough/filament.json
@@ -3,5 +3,9 @@
   "id": "pla_tough",
   "name": "PLA Tough",
   "diameter_tolerance": 0.02,
-  "density": 1.2
+  "density": 1.2,
+  "min_print_temperature": 190,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/safeguard_pla/filament.json
+++ b/data/spectrum/PLA/safeguard_pla/filament.json
@@ -3,5 +3,9 @@
   "id": "safeguard_pla",
   "name": "SafeGuard PLA",
   "diameter_tolerance": 0.02,
-  "density": 1.24
+  "density": 1.24,
+  "min_print_temperature": 185,
+  "max_print_temperature": 215,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PLA/wood/filament.json
+++ b/data/spectrum/PLA/wood/filament.json
@@ -3,5 +3,9 @@
   "id": "wood",
   "name": "PLA WOOD",
   "diameter_tolerance": 0.02,
-  "density": 1.15
+  "density": 1.15,
+  "min_print_temperature": 190,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 0,
+  "max_bed_temperature": 45
 }

--- a/data/spectrum/PP/pp/filament.json
+++ b/data/spectrum/PP/pp/filament.json
@@ -3,5 +3,9 @@
   "id": "pp",
   "name": "PP",
   "diameter_tolerance": 0.02,
-  "density": 0.89
+  "density": 0.89,
+  "min_print_temperature": 265,
+  "max_print_temperature": 295,
+  "min_bed_temperature": 95,
+  "max_bed_temperature": 120
 }

--- a/data/spectrum/PPS/pps_am230/filament.json
+++ b/data/spectrum/PPS/pps_am230/filament.json
@@ -3,5 +3,9 @@
   "id": "pps_am230",
   "name": "PPS AM230",
   "diameter_tolerance": 0.02,
-  "density": 1.33
+  "density": 1.33,
+  "min_print_temperature": 300,
+  "max_print_temperature": 330,
+  "min_bed_temperature": 100,
+  "max_bed_temperature": 120
 }

--- a/data/spectrum/TPU/s_flex_85a/filament.json
+++ b/data/spectrum/TPU/s_flex_85a/filament.json
@@ -3,5 +3,9 @@
   "id": "s_flex_85a",
   "name": "TPU S-Flex 85A",
   "diameter_tolerance": 0.02,
-  "density": 1.11
+  "density": 1.11,
+  "min_print_temperature": 200,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 70
 }

--- a/data/spectrum/TPU/s_flex_90a/filament.json
+++ b/data/spectrum/TPU/s_flex_90a/filament.json
@@ -3,5 +3,9 @@
   "id": "s_flex_90a",
   "name": "TPU S-Flex 90A",
   "diameter_tolerance": 0.02,
-  "density": 1.22
+  "density": 1.22,
+  "min_print_temperature": 200,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 70
 }

--- a/data/spectrum/TPU/s_flex_98a/filament.json
+++ b/data/spectrum/TPU/s_flex_98a/filament.json
@@ -3,5 +3,9 @@
   "id": "s_flex_98a",
   "name": "TPU S-Flex 98A",
   "diameter_tolerance": 0.02,
-  "density": 1.09
+  "density": 1.09,
+  "min_print_temperature": 200,
+  "max_print_temperature": 230,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 70
 }

--- a/data/spectrum/TPU/s_flex_carbon/filament.json
+++ b/data/spectrum/TPU/s_flex_carbon/filament.json
@@ -3,5 +3,9 @@
   "id": "s_flex_carbon",
   "name": "TPU S-Flex Carbon",
   "diameter_tolerance": 0.02,
-  "density": 1.09
+  "density": 1.09,
+  "min_print_temperature": 210,
+  "max_print_temperature": 245,
+  "min_bed_temperature": 45,
+  "max_bed_temperature": 70
 }

--- a/data/unitak3d/PLA/pla_matte/filament.json
+++ b/data/unitak3d/PLA/pla_matte/filament.json
@@ -4,5 +4,9 @@
   "name": "PLA Matte",
   "diameter_tolerance": 0.03,
   "density": 1.26,
-  "max_dry_temperature": 50
+  "max_dry_temperature": 50,
+  "min_print_temperature": 190,
+  "max_print_temperature": 220,
+  "min_bed_temperature": 50,
+  "max_bed_temperature": 65
 }


### PR DESCRIPTION
This is batch 1 of the temperature backfill we offered on #400. 80 filaments
whose print and bed temperature fields were empty, each filled from that
filament's own manufacturer datasheet or product page.

| Brand | Entries |
|---|---|
| spectrum | 60 |
| fiberlogy | 10 |
| amolen | 2 |
| colorfabb | 2 |
| copymaster | 1 |
| flashforge | 1 |
| polar_filament | 1 |
| polymide | 1 |
| smart_materials_3d | 1 |
| unitak3d | 1 |

**Only previously-empty fields were written.** No existing value was changed
anywhere in this branch. Where a value was already present it was left alone,
even in the handful of cases where the manufacturer's current datasheet
disagrees with it; those felt like a separate conversation rather than
something to slip into a backfill.

The branch is built on current `main` and the diff is the four temperature
fields and nothing else, so it should be quick to scan. `ofd validate` passes.

A note on sourcing, since 80 entries is a lot to take on trust: every value
came from the manufacturer's own datasheet or product page for that specific
filament. Nothing was averaged, inferred from a sibling product, or copied
from a reseller listing. Where a manufacturer published no temperatures we
left the filament out of this batch rather than guess, which is why some
brands here contribute only one entry.

Happy to split this by brand if a single 80-entry PR is harder to review than
you expected, or to adjust anything. Contributed by SpoolBites (spoolbites.com).
