### PR TITLE
Add ELEGOO PETG Transparent variant

### DIFF
--- a/data/elegoo/PETG/petg/transparent/sizes.json
+++ b/data/elegoo/PETG/petg/transparent/sizes.json
@@ -1,0 +1,15 @@
+[
+  {
+    "filament_weight": 1000,
+    "diameter": 1.75,
+    "spool_refill": false,
+    "article_number": "CA-EL-3D-PEB10",
+    "discontinued": false,
+    "purchase_links": [
+      {
+        "store_id": "amazon",
+        "url": "https://www.amazon.com/dp/B0D41ZMR4G"
+      }
+    ]
+  }
+]

--- a/data/elegoo/PETG/petg/transparent/variant.json
+++ b/data/elegoo/PETG/petg/transparent/variant.json
@@ -1,0 +1,9 @@
+{
+  "id": "transparent",
+  "name": "Transparent",
+  "color_hex": "#FFFFFF",
+  "discontinued": false,
+  "traits": {
+    "transparent": true
+  }
+}


### PR DESCRIPTION
Adds the Transparent color variant for ELEGOO PETG.
Source:
- Amazon ASIN: B0D41ZMR4G
- Manufacturer part number: CA-EL-3D-PEB10
- 1.75 mm, 1000 g
- The physical spool label identifies the filament as PETG and the color as Transparent.
The Amazon listing also identifies this variant as PETG Transparent 1kg.

## Changes
- [+] Created variant "Transparent"

*Submitted by @kernel-kedr via the OFD web editor*